### PR TITLE
Implement `Error` for error types

### DIFF
--- a/src/common/stack.rs
+++ b/src/common/stack.rs
@@ -1,5 +1,6 @@
 
 use std::collections::VecDeque;
+use std::error;
 use std::fmt;
 
 #[derive(Debug)]
@@ -8,6 +9,12 @@ pub struct Error(String);
 impl fmt::Display for Error {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(f, "{}", self.0)
+	}
+}
+
+impl error::Error for Error {
+	fn description(&self) -> &str {
+		&self.0
 	}
 }
 

--- a/src/elements/mod.rs
+++ b/src/elements/mod.rs
@@ -106,9 +106,9 @@ impl fmt::Display for Error {
             Error::UnknownExternalKind(kind) => write!(f, "Unknown external kind {}", kind),
             Error::UnknownInternalKind(kind) => write!(f, "Unknown internal kind {}", kind),
             Error::UnknownOpcode(opcode) => write!(f, "Unknown opcode {}", opcode),
-            Error::InvalidVarUint1(val) => write!(f, "Not a unsigned 1-bit integer: {}", val),
+            Error::InvalidVarUint1(val) => write!(f, "Not an unsigned 1-bit integer: {}", val),
             Error::InvalidVarInt32 => write!(f, "Not a signed 32-bit integer"),
-            Error::InvalidVarInt64 => write!(f, "Not a signed 32-bit integer"),
+            Error::InvalidVarInt64 => write!(f, "Not a signed 64-bit integer"),
         }
     }
 }
@@ -128,9 +128,9 @@ impl error::Error for Error {
             Error::UnknownExternalKind(_) => "Unknown external kind",
             Error::UnknownInternalKind(_) => "Unknown internal kind",
             Error::UnknownOpcode(_) => "Unknown opcode",
-            Error::InvalidVarUint1(_) => "Not a unsigned 1-bit integer",
+            Error::InvalidVarUint1(_) => "Not an unsigned 1-bit integer",
             Error::InvalidVarInt32 => "Not a signed 32-bit integer",
-            Error::InvalidVarInt64 => "Not a signed 32-bit integer",
+            Error::InvalidVarInt64 => "Not a signed 64-bit integer",
         }
     }
 }

--- a/src/elements/mod.rs
+++ b/src/elements/mod.rs
@@ -1,5 +1,7 @@
 //! Elements of the WebAssembly binary format.
 
+use std::error;
+use std::fmt;
 use std::io;
 
 mod module;
@@ -85,6 +87,52 @@ pub enum Error {
     InvalidVarInt32,
     /// Invalid VarInt64 value
     InvalidVarInt64,
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Error::UnexpectedEof => write!(f, "Unexpected end of input"),
+            Error::InvalidMagic => write!(f, "Invalid magic number at start of file"),
+            Error::UnsupportedVersion(v) => write!(f, "Unsupported wasm version {}", v),
+            Error::InconsistentLength { expected, actual } => {
+                write!(f, "Expected length {}, found {}", expected, actual)
+            }
+            Error::Other(msg) => write!(f, "{}", msg),
+            Error::HeapOther(ref msg) => write!(f, "{}", msg),
+            Error::UnknownValueType(ty) => write!(f, "Invalid or unknown value type {}", ty),
+            Error::UnknownTableElementType(ty) => write!(f, "Unknown table element type {}", ty),
+            Error::NonUtf8String => write!(f, "Non-UTF-8 string"),
+            Error::UnknownExternalKind(kind) => write!(f, "Unknown external kind {}", kind),
+            Error::UnknownInternalKind(kind) => write!(f, "Unknown internal kind {}", kind),
+            Error::UnknownOpcode(opcode) => write!(f, "Unknown opcode {}", opcode),
+            Error::InvalidVarUint1(val) => write!(f, "Not a unsigned 1-bit integer: {}", val),
+            Error::InvalidVarInt32 => write!(f, "Not a signed 32-bit integer"),
+            Error::InvalidVarInt64 => write!(f, "Not a signed 32-bit integer"),
+        }
+    }
+}
+
+impl error::Error for Error {
+    fn description(&self) -> &str {
+        match *self {
+            Error::UnexpectedEof => "Unexpected end of input",
+            Error::InvalidMagic => "Invalid magic number at start of file",
+            Error::UnsupportedVersion(_) => "Unsupported wasm version",
+            Error::InconsistentLength { .. } => "Inconsistent length",
+            Error::Other(msg) => msg,
+            Error::HeapOther(ref msg) => &msg[..],
+            Error::UnknownValueType(_) => "Invalid or unknown value type",
+            Error::UnknownTableElementType(_) => "Unknown table element type",
+            Error::NonUtf8String => "Non-UTF-8 string",
+            Error::UnknownExternalKind(_) => "Unknown external kind",
+            Error::UnknownInternalKind(_) => "Unknown internal kind",
+            Error::UnknownOpcode(_) => "Unknown opcode",
+            Error::InvalidVarUint1(_) => "Not a unsigned 1-bit integer",
+            Error::InvalidVarInt32 => "Not a signed 32-bit integer",
+            Error::InvalidVarInt64 => "Not a signed 32-bit integer",
+        }
+    }
 }
 
 impl From<io::Error> for Error {

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -1,6 +1,8 @@
 //! WebAssembly interpreter module.
 
 use std::any::TypeId;
+use std::error;
+use std::fmt;
 use validation;
 use common;
 
@@ -90,8 +92,8 @@ impl Into<String> for Error {
 	}
 }
 
-impl ::std::fmt::Display for Error {
-	fn fmt(&self, f: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> {
+impl fmt::Display for Error {
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		match *self {
 			Error::Program(ref s) => write!(f, "Program: {}", s),
 			Error::Validation(ref s) => write!(f, "Validation: {}", s),
@@ -108,6 +110,28 @@ impl ::std::fmt::Display for Error {
 			Error::Native(ref s) => write!(f, "Native: {}", s),
 			Error::Trap(ref s) => write!(f, "Trap: {}", s),
 			Error::User(ref e) => write!(f, "User: {}", e),
+		}
+	}
+}
+
+impl error::Error for Error {
+	fn description(&self) -> &str {
+		match *self {
+			Error::Program(ref s) => s,
+			Error::Validation(ref s) => s,
+			Error::Initialization(ref s) => s,
+			Error::Function(ref s) => s,
+			Error::Table(ref s) => s,
+			Error::Memory(ref s) => s,
+			Error::Variable(ref s) => s,
+			Error::Global(ref s) => s,
+			Error::Local(ref s) => s,
+			Error::Stack(ref s) => s,
+			Error::Interpreter(ref s) => s,
+			Error::Value(ref s) => s,
+			Error::Native(ref s) => s,
+			Error::Trap(ref s) => s,
+			Error::User(_) => "User error",
 		}
 	}
 }

--- a/src/validation/mod.rs
+++ b/src/validation/mod.rs
@@ -1,3 +1,4 @@
+use std::error;
 use std::fmt;
 use elements::{
 	BlockType, External, GlobalEntry, GlobalType, Internal, MemoryType,
@@ -22,6 +23,12 @@ pub struct Error(String);
 impl fmt::Display for Error {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(f, "{}", self.0)
+	}
+}
+
+impl error::Error for Error {
+	fn description(&self) -> &str {
+		&self.0
 	}
 }
 


### PR DESCRIPTION
This makes it easier to handle errors from parity-wasm in an idiomatic fashion.

Fixes #125.