### PR TITLE
Made default module magic number endian-independent.

### DIFF
--- a/src/elements/module.rs
+++ b/src/elements/module.rs
@@ -20,7 +20,7 @@ pub struct Module {
 impl Default for Module {
     fn default() -> Self {
         Module {
-            magic: 0x6d736100,
+            magic: LittleEndian::read_u32(&WASM_MAGIC_NUMBER),
             version: 1,
             sections: Vec::with_capacity(16),
         }
@@ -388,5 +388,14 @@ mod integration_tests {
         buf.extend_from_slice(&[0, 0, 0, 0, 0, 1, 5, 12, 17]);
 
         assert_eq!(peek_size(&buf), buf.len() - 9);
+    }
+
+    #[test]
+    fn module_default_round_trip() {
+        let module1 = Module::default();
+        let buf = serialize(module1).expect("Serialization should succeed");
+        
+        let module2: Module = deserialize_buffer(&buf).expect("Deserialization should succeed");
+        assert_eq!(Module::default().magic, module2.magic);
     }
 }


### PR DESCRIPTION
And added unit test.  You can change the `LittleEndian` to `BigEndian` in `Module::default()` and see what it would otherwise do when built on a big-endian platform.

Resolves issue #134 