### PR TITLE
Replaced mysterous bool's in opcodes with u8

### DIFF
--- a/src/elements/mod.rs
+++ b/src/elements/mod.rs
@@ -25,7 +25,7 @@ pub use self::import_entry::{ImportEntry, ResizableLimits, MemoryType, TableType
 pub use self::export_entry::{ExportEntry, Internal};
 pub use self::global_entry::GlobalEntry;
 pub use self::primitives::{
-    VarUint32, VarUint7, VarUint8, VarUint1, VarInt7, Uint32, VarInt32, VarInt64,
+    VarUint32, VarUint7, Uint8, VarUint1, VarInt7, Uint32, VarInt32, VarInt64,
     Uint64, VarUint64, CountedList, CountedWriter, CountedListWriter,
 };
 pub use self::types::{Type, ValueType, BlockType, FunctionType, TableElementType};

--- a/src/elements/mod.rs
+++ b/src/elements/mod.rs
@@ -25,7 +25,7 @@ pub use self::import_entry::{ImportEntry, ResizableLimits, MemoryType, TableType
 pub use self::export_entry::{ExportEntry, Internal};
 pub use self::global_entry::GlobalEntry;
 pub use self::primitives::{
-    VarUint32, VarUint7, VarUint1, VarInt7, Uint32, VarInt32, VarInt64,
+    VarUint32, VarUint7, VarUint8, VarUint1, VarInt7, Uint32, VarInt32, VarInt64,
     Uint64, VarUint64, CountedList, CountedWriter, CountedListWriter,
 };
 pub use self::types::{Type, ValueType, BlockType, FunctionType, TableElementType};

--- a/src/elements/ops.rs
+++ b/src/elements/ops.rs
@@ -1,7 +1,7 @@
 use std::{io, fmt};
 use super::{
     Serialize, Deserialize, Error, VarUint7,
-    VarUint1, VarUint32, CountedList, BlockType,
+    VarUint32, CountedList, BlockType,
     Uint32, Uint64, CountedListWriter,
     VarInt32, VarInt64,
 };
@@ -117,7 +117,7 @@ pub enum Opcode {
     Return,
 
     Call(u32),
-    CallIndirect(u32, bool),
+    CallIndirect(u32, u8),
 
     Drop,
     Select,
@@ -154,8 +154,8 @@ pub enum Opcode {
     I64Store16(u32, u32),
     I64Store32(u32, u32),
 
-    CurrentMemory(bool),
-    GrowMemory(bool),
+    CurrentMemory(u8),
+    GrowMemory(u8),
 
     I32Const(i32),
     I64Const(i64),
@@ -346,7 +346,7 @@ impl Deserialize for Opcode {
                 0x10 => Call(VarUint32::deserialize(reader)?.into()),
                 0x11 => CallIndirect(
                     VarUint32::deserialize(reader)?.into(),
-                    VarUint1::deserialize(reader)?.into()),
+                    VarUint7::deserialize(reader)?.into()),
                 0x1a => Drop,
                 0x1b => Select,
 
@@ -449,8 +449,8 @@ impl Deserialize for Opcode {
                     VarUint32::deserialize(reader)?.into()),
 
 
-                0x3f => CurrentMemory(VarUint1::deserialize(reader)?.into()),
-                0x40 => GrowMemory(VarUint1::deserialize(reader)?.into()),
+                0x3f => CurrentMemory(VarUint7::deserialize(reader)?.into()),
+                0x40 => GrowMemory(VarUint7::deserialize(reader)?.into()),
 
                 0x41 => I32Const(VarInt32::deserialize(reader)?.into()),
                 0x42 => I64Const(VarInt64::deserialize(reader)?.into()),
@@ -644,7 +644,7 @@ impl Serialize for Opcode {
             }),
             CallIndirect(index, reserved) => op!(writer, 0x11, {
                 VarUint32::from(index).serialize(writer)?;
-                VarUint1::from(reserved).serialize(writer)?;
+                VarUint7::from(reserved).serialize(writer)?;
             }),
             Drop => op!(writer, 0x1a),
             Select => op!(writer, 0x1b),
@@ -756,10 +756,10 @@ impl Serialize for Opcode {
                 VarUint32::from(offset).serialize(writer)?;
             }),
             CurrentMemory(flag) => op!(writer, 0x3f, {
-                VarUint1::from(flag).serialize(writer)?;
+                VarUint7::from(flag).serialize(writer)?;
             }),
             GrowMemory(flag) => op!(writer, 0x40, {
-                VarUint1::from(flag).serialize(writer)?;
+                VarUint7::from(flag).serialize(writer)?;
             }),
             I32Const(def) => op!(writer, 0x41, {
                 VarInt32::from(def).serialize(writer)?;

--- a/src/elements/ops.rs
+++ b/src/elements/ops.rs
@@ -1,7 +1,7 @@
 use std::{io, fmt};
 use super::{
-    Serialize, Deserialize, Error, VarUint7,
-    VarUint8, VarUint32, CountedList, BlockType,
+    Serialize, Deserialize, Error,
+    Uint8, VarUint32, CountedList, BlockType,
     Uint32, Uint64, CountedListWriter,
     VarInt32, VarInt64,
 };
@@ -319,7 +319,7 @@ impl Deserialize for Opcode {
     fn deserialize<R: io::Read>(reader: &mut R) -> Result<Self, Self::Error> {
         use self::Opcode::*;
 
-        let val: u8 = VarUint7::deserialize(reader)?.into();
+        let val: u8 = Uint8::deserialize(reader)?.into();
 
         Ok(
             match val {
@@ -346,7 +346,7 @@ impl Deserialize for Opcode {
                 0x10 => Call(VarUint32::deserialize(reader)?.into()),
                 0x11 => CallIndirect(
                     VarUint32::deserialize(reader)?.into(),
-                    VarUint8::deserialize(reader)?.into()),
+                    Uint8::deserialize(reader)?.into()),
                 0x1a => Drop,
                 0x1b => Select,
 
@@ -449,8 +449,8 @@ impl Deserialize for Opcode {
                     VarUint32::deserialize(reader)?.into()),
 
 
-                0x3f => CurrentMemory(VarUint8::deserialize(reader)?.into()),
-                0x40 => GrowMemory(VarUint8::deserialize(reader)?.into()),
+                0x3f => CurrentMemory(Uint8::deserialize(reader)?.into()),
+                0x40 => GrowMemory(Uint8::deserialize(reader)?.into()),
 
                 0x41 => I32Const(VarInt32::deserialize(reader)?.into()),
                 0x42 => I64Const(VarInt64::deserialize(reader)?.into()),
@@ -644,7 +644,7 @@ impl Serialize for Opcode {
             }),
             CallIndirect(index, reserved) => op!(writer, 0x11, {
                 VarUint32::from(index).serialize(writer)?;
-                VarUint7::from(reserved).serialize(writer)?;
+                Uint8::from(reserved).serialize(writer)?;
             }),
             Drop => op!(writer, 0x1a),
             Select => op!(writer, 0x1b),
@@ -756,10 +756,10 @@ impl Serialize for Opcode {
                 VarUint32::from(offset).serialize(writer)?;
             }),
             CurrentMemory(flag) => op!(writer, 0x3f, {
-                VarUint7::from(flag).serialize(writer)?;
+                Uint8::from(flag).serialize(writer)?;
             }),
             GrowMemory(flag) => op!(writer, 0x40, {
-                VarUint7::from(flag).serialize(writer)?;
+                Uint8::from(flag).serialize(writer)?;
             }),
             I32Const(def) => op!(writer, 0x41, {
                 VarInt32::from(def).serialize(writer)?;

--- a/src/elements/ops.rs
+++ b/src/elements/ops.rs
@@ -1,7 +1,7 @@
 use std::{io, fmt};
 use super::{
     Serialize, Deserialize, Error, VarUint7,
-    VarUint32, CountedList, BlockType,
+    VarUint8, VarUint32, CountedList, BlockType,
     Uint32, Uint64, CountedListWriter,
     VarInt32, VarInt64,
 };
@@ -346,7 +346,7 @@ impl Deserialize for Opcode {
                 0x10 => Call(VarUint32::deserialize(reader)?.into()),
                 0x11 => CallIndirect(
                     VarUint32::deserialize(reader)?.into(),
-                    VarUint7::deserialize(reader)?.into()),
+                    VarUint8::deserialize(reader)?.into()),
                 0x1a => Drop,
                 0x1b => Select,
 
@@ -449,8 +449,8 @@ impl Deserialize for Opcode {
                     VarUint32::deserialize(reader)?.into()),
 
 
-                0x3f => CurrentMemory(VarUint7::deserialize(reader)?.into()),
-                0x40 => GrowMemory(VarUint7::deserialize(reader)?.into()),
+                0x3f => CurrentMemory(VarUint8::deserialize(reader)?.into()),
+                0x40 => GrowMemory(VarUint8::deserialize(reader)?.into()),
 
                 0x41 => I32Const(VarInt32::deserialize(reader)?.into()),
                 0x42 => I64Const(VarInt64::deserialize(reader)?.into()),

--- a/src/elements/primitives.rs
+++ b/src/elements/primitives.rs
@@ -206,6 +206,43 @@ impl Serialize for VarInt7 {
     }
 }
 
+/// 8-bit unsigned integer, NOT encoded in LEB128;
+/// it's just a single byte.
+#[derive(Debug, Copy, Clone)]
+pub struct VarUint8(u8);
+
+impl From<VarUint8> for u8 {
+    fn from(v: VarUint8) -> u8 {
+        v.0
+    }
+}
+
+impl From<u8> for VarUint8 {
+    fn from(v: u8) -> Self {
+        VarUint8(v)
+    }
+}
+
+impl Deserialize for VarUint8 {
+    type Error = Error;
+
+    fn deserialize<R: io::Read>(reader: &mut R) -> Result<Self, Self::Error> {
+        let mut u8buf = [0u8; 1];
+        reader.read_exact(&mut u8buf)?;
+        Ok(VarUint8(u8buf[0]))
+    }
+}
+
+impl Serialize for VarUint8 {
+    type Error = Error;
+
+    fn serialize<W: io::Write>(self, writer: &mut W) -> Result<(), Self::Error> {
+        writer.write_all(&[self.0])?;
+        Ok(())
+    }
+}
+
+
 /// 32-bit signed integer, encoded in LEB128 (can be 1-5 bytes length)
 #[derive(Debug, Copy, Clone)]
 pub struct VarInt32(i32);

--- a/src/elements/primitives.rs
+++ b/src/elements/primitives.rs
@@ -209,31 +209,31 @@ impl Serialize for VarInt7 {
 /// 8-bit unsigned integer, NOT encoded in LEB128;
 /// it's just a single byte.
 #[derive(Debug, Copy, Clone)]
-pub struct VarUint8(u8);
+pub struct Uint8(u8);
 
-impl From<VarUint8> for u8 {
-    fn from(v: VarUint8) -> u8 {
+impl From<Uint8> for u8 {
+    fn from(v: Uint8) -> u8 {
         v.0
     }
 }
 
-impl From<u8> for VarUint8 {
+impl From<u8> for Uint8 {
     fn from(v: u8) -> Self {
-        VarUint8(v)
+        Uint8(v)
     }
 }
 
-impl Deserialize for VarUint8 {
+impl Deserialize for Uint8 {
     type Error = Error;
 
     fn deserialize<R: io::Read>(reader: &mut R) -> Result<Self, Self::Error> {
         let mut u8buf = [0u8; 1];
         reader.read_exact(&mut u8buf)?;
-        Ok(VarUint8(u8buf[0]))
+        Ok(Uint8(u8buf[0]))
     }
 }
 
-impl Serialize for VarUint8 {
+impl Serialize for Uint8 {
     type Error = Error;
 
     fn serialize<W: io::Write>(self, writer: &mut W) -> Result<(), Self::Error> {

--- a/src/interpreter/tests/wabt.rs
+++ b/src/interpreter/tests/wabt.rs
@@ -632,7 +632,7 @@ fn callindirect_1() {
 
 	let body3 = Opcodes::new(vec![
 		Opcode::GetLocal(0),
-		Opcode::CallIndirect(0, false),
+		Opcode::CallIndirect(0, 0),
 		Opcode::End,
 	]);
 
@@ -691,7 +691,7 @@ fn callindirect_2() {
 		Opcode::GetLocal(0),
 		Opcode::GetLocal(1),
 		Opcode::GetLocal(2),
-		Opcode::CallIndirect(0, false),
+		Opcode::CallIndirect(0, 0),
 		Opcode::End,
 	]);
 


### PR DESCRIPTION
I suppose, looking at the code, a bool is always represented as u8, which is what we want anyway, but since these values are not bools but placeholder integers that must currently always be 0, having them be bools is kind of strange.

Replaced the reading/writing of them with VarUint7, which is maybe almost as invalid, but works.

Resolves #145.

Sorry I keep PR'ing API-breaking changes!  😅 