### PR TITLE
Use binaryen-rs for in-process wasm fuzzing

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "spec/wabt"]
 	path = spec/wabt
 	url = https://github.com/WebAssembly/wabt
-[submodule "fuzz/binaryen"]
-	path = fuzz/binaryen
-	url = https://github.com/WebAssembly/binaryen

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -4,13 +4,12 @@ name = "parity-wasm-fuzz"
 version = "0.0.1"
 authors = ["Pat Hickey phickey@fastly.com"]
 publish = false
-build = "build.rs"
-
-[build-dependencies]
-cmake = "0.1"
 
 [package.metadata]
 cargo-fuzz = true
+
+[dependencies.binaryen]
+version = "0.3.0"
 
 [dependencies.parity-wasm]
 path = ".."

--- a/fuzz/build.rs
+++ b/fuzz/build.rs
@@ -1,7 +1,0 @@
-extern crate cmake;
-use cmake::Config;
-
-fn main() {
-    let _dst = Config::new("binaryen")
-        .build();
-}

--- a/fuzz/fuzz_targets/deserialize.rs
+++ b/fuzz/fuzz_targets/deserialize.rs
@@ -2,54 +2,17 @@
 #[macro_use]
 extern crate libfuzzer_sys;
 extern crate parity_wasm;
-extern crate mktemp;
-
-use std::fs::File;
-use std::io::Write;
-use std::path::PathBuf;
-use std::process::Command;
-
-fn wasm_opt() -> PathBuf {
-    let bin = PathBuf::from(env!("OUT_DIR")).join("bin").join("wasm-opt");
-    assert!(
-        bin.exists(),
-        format!(
-            "could not find wasm-opt at location installed by build.rs: {:?}",
-            wasm_opt()
-        )
-    );
-    bin
-}
+extern crate binaryen;
 
 fuzz_target!(|data: &[u8]| {
-    let seed = mktemp::Temp::new_file().expect("mktemp file to store fuzzer input");
-    let mut seedfile =
-        File::create(seed.as_ref()).expect("open temporary file for writing to store fuzzer input");
-    seedfile.write_all(data).expect(
-        "write fuzzer input to temporary file",
-    );
-    seedfile.flush().expect(
-        "flush fuzzer input to temporary file before starting wasm-opt",
-    );
+    let binaryen_module = binaryen::tools::translate_to_fuzz(data);
 
-    let wasm = mktemp::Temp::new_file().expect("mktemp file to store wasm-opt output");
-    let opt_fuzz = Command::new(wasm_opt())
-        .arg("--translate-to-fuzz")
-        .arg(seed.as_ref())
-        .arg("-o")
-        .arg(wasm.as_ref())
-        .output()
-        .expect("execute wasm-opt installed by build.rs");
+    // enable binaryen's validation if in doubt.
+    // assert!(binaryen_module.is_valid());
 
-    assert!(
-        opt_fuzz.status.success(),
-        format!(
-            "wasm-opt failed with: {}",
-            String::from_utf8_lossy(&opt_fuzz.stderr)
-        )
-    );
+    let wasm = binaryen_module.write();
 
-    let _module: parity_wasm::elements::Module = parity_wasm::deserialize_file(wasm.as_ref())
+    let _module: parity_wasm::elements::Module = parity_wasm::deserialize_buffer(&wasm)
         .expect(
             "deserialize output of wasm-opt, indicating possible bug in deserializer",
         );


### PR DESCRIPTION
Resolves #150 

This change let us dropping the direct binaryen dependency and greatly speed ups fuzzing on my local tests.

Before: several dozens of iterations per second
After: 900-950 iterations per second