### PR TITLE
Toy decoder bench example

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ script:
 - cargo test --release --verbose
 - cargo test --release --manifest-path=spec/Cargo.toml
 - cargo test --manifest-path=pwasm-emscripten/Cargo.toml
-- cargo run --release --example roundtrip ./res/cases/v1/clang.wasm /tmp/clang.wasm
 - cargo run --example bench-decoder --release
 after_success: |-
   [ $TRAVIS_BRANCH = master ] &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ script:
 - cargo test --release --manifest-path=spec/Cargo.toml
 - cargo test --manifest-path=pwasm-emscripten/Cargo.toml
 - cargo run --release --example roundtrip ./res/cases/v1/clang.wasm /tmp/clang.wasm
+- cargo run --example bench-decoder --release
 after_success: |-
   [ $TRAVIS_BRANCH = master ] &&
   [ $TRAVIS_PULL_REQUEST = false ] &&

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ exclude = [ "res/*", "spec/*" ]
 log = "0.3"
 byteorder = "1.0"
 parking_lot = "0.5"
+time = "*"

--- a/examples/bench-decoder.rs
+++ b/examples/bench-decoder.rs
@@ -6,7 +6,7 @@ extern crate time;
 use std::fs;
 
 fn rate(file_name: &'static str, iterations: u64) {
-    let file_size = fs::metadata(file_name).expect(&format!("{} to exist", file_name)).len();
+	let file_size = fs::metadata(file_name).expect(&format!("{} to exist", file_name)).len();
 	let mut total_ms = 0;
 
 	for _ in 0..iterations {

--- a/examples/bench-decoder.rs
+++ b/examples/bench-decoder.rs
@@ -1,0 +1,30 @@
+#![feature(test)]
+
+extern crate parity_wasm;
+extern crate time;
+
+use std::fs;
+
+fn rate(file_name: &'static str, iterations: u64) {
+    let file_size = fs::metadata(file_name).expect(&format!("{} to exist", file_name)).len();
+	let mut total_ms = 0;
+
+	for _ in 0..iterations {
+		let start = time::PreciseTime::now();
+		let _module = parity_wasm::deserialize_file(file_name);
+		let end = time::PreciseTime::now();
+
+		total_ms += start.to(end).num_milliseconds();
+	}
+
+	println!("Rate for {}: {} MB/s", file_name,
+		(file_size as f64 * iterations as f64 / (1024*1024) as f64) /  // total work megabytes
+		(total_ms as f64 / 1000f64)									   // total seconds
+	);
+}
+
+fn main() {
+	rate("./res/cases/v1/clang.wasm", 10);
+	rate("./res/cases/v1/hello.wasm", 100);
+	rate("./res/cases/v1/with_names.wasm", 100);
+}

--- a/examples/bench-decoder.rs
+++ b/examples/bench-decoder.rs
@@ -1,5 +1,3 @@
-#![feature(test)]
-
 extern crate parity_wasm;
 extern crate time;
 


### PR DESCRIPTION
There is some non-linearity :(

Rate for ./res/cases/v1/clang.wasm: 29.10402837487349 MB/s
Rate for ./res/cases/v1/hello.wasm: 81.48502659153294 MB/s
Rate for ./res/cases/v1/with_names.wasm: 36.43022734543373 MB/s