### PR TITLE
Fix some fuzzer bugs

### DIFF
--- a/src/elements/func.rs
+++ b/src/elements/func.rs
@@ -3,6 +3,7 @@ use super::{
 	Deserialize, Error, ValueType, VarUint32, CountedList, Opcodes,
 	Serialize, CountedWriter, CountedListWriter,
 };
+use elements::section::SectionReader;
 
 /// Function signature (type reference)
 #[derive(Debug, Copy, Clone)]
@@ -116,9 +117,10 @@ impl Deserialize for FuncBody {
 
 	fn deserialize<R: io::Read>(reader: &mut R) -> Result<Self, Self::Error> {
 		// todo: maybe use reader.take(section_length)
-		let _body_size = VarUint32::deserialize(reader)?;
-		let locals: Vec<Local> = CountedList::deserialize(reader)?.into_inner();
-		let opcodes = Opcodes::deserialize(reader)?;
+		let mut body_reader = SectionReader::new(reader)?;
+		let locals: Vec<Local> = CountedList::<Local>::deserialize(&mut body_reader)?.into_inner();
+		let opcodes = Opcodes::deserialize(&mut body_reader)?;
+		body_reader.close()?;
 		Ok(FuncBody { locals: locals, opcodes: opcodes })
 	}
 }

--- a/src/elements/mod.rs
+++ b/src/elements/mod.rs
@@ -4,9 +4,9 @@ use std::error;
 use std::fmt;
 use std::io;
 
+mod primitives;
 mod module;
 mod section;
-mod primitives;
 mod types;
 mod import_entry;
 mod export_entry;

--- a/src/elements/mod.rs
+++ b/src/elements/mod.rs
@@ -100,6 +100,8 @@ pub enum Error {
 	InvalidVarUint64,
 	/// Inconsistent metadata
 	InconsistentMetadata,
+	/// Invalid section id
+	InvalidSectionId(u8),
 }
 
 impl fmt::Display for Error {
@@ -125,6 +127,7 @@ impl fmt::Display for Error {
 			Error::InvalidVarInt64 => write!(f, "Not a signed 64-bit integer"),
 			Error::InvalidVarUint64 => write!(f, "Not an unsigned 64-bit integer"),
 			Error::InconsistentMetadata =>  write!(f, "Inconsistent metadata"),
+			Error::InvalidSectionId(ref id) =>  write!(f, "Invalid section id: {}", id),
 		}
 	}
 }
@@ -150,6 +153,7 @@ impl error::Error for Error {
 			Error::InvalidVarInt64 => "Not a signed 64-bit integer",
 			Error::InvalidVarUint64 => "Not an unsigned 64-bit integer",
 			Error::InconsistentMetadata => "Inconsistent metadata",
+			Error::InvalidSectionId(_) =>  "Invalid section id",
 		}
 	}
 }

--- a/src/elements/mod.rs
+++ b/src/elements/mod.rs
@@ -215,7 +215,6 @@ pub fn deserialize_file<P: AsRef<::std::path::Path>>(p: P) -> Result<Module, Err
 pub fn deserialize_buffer<T: Deserialize>(contents: &[u8]) -> Result<T, T::Error> {
 	let mut reader = io::Cursor::new(contents);
 	let result = T::deserialize(&mut reader)?;
-	println!("position: {}, content.len: {}", reader.position(), contents.len());
 	if reader.position() != contents.len() as u64 {
 		return Err(io::Error::from(io::ErrorKind::InvalidData).into())
 	}

--- a/src/elements/mod.rs
+++ b/src/elements/mod.rs
@@ -40,10 +40,16 @@ pub use self::name_section::{
 	LocalNameSection,
 };
 
+/// Generic buffer error for deserializing
+pub trait BufferError : Sized {
+	/// Return buffer error instance
+	fn buffer() -> Self;
+}
+
 /// Deserialization from serial i/o
 pub trait Deserialize : Sized {
 	/// Serialization error produced by deserialization routine.
-	type Error;
+	type Error: BufferError;
 	/// Deserialize type from serial i/o
 	fn deserialize<R: io::Read>(reader: &mut R) -> Result<Self, Self::Error>;
 }
@@ -102,6 +108,14 @@ pub enum Error {
 	InconsistentMetadata,
 	/// Invalid section id
 	InvalidSectionId(u8),
+	/// There is still data left in the buffer
+	BufferUnderflow,
+}
+
+impl BufferError for Error {
+	fn buffer() -> Self {
+		Error::BufferUnderflow
+	}
 }
 
 impl fmt::Display for Error {
@@ -128,6 +142,7 @@ impl fmt::Display for Error {
 			Error::InvalidVarUint64 => write!(f, "Not an unsigned 64-bit integer"),
 			Error::InconsistentMetadata =>  write!(f, "Inconsistent metadata"),
 			Error::InvalidSectionId(ref id) =>  write!(f, "Invalid section id: {}", id),
+			Error::BufferUnderflow => write!(f, "Buffer underflow"),
 		}
 	}
 }
@@ -154,6 +169,7 @@ impl error::Error for Error {
 			Error::InvalidVarUint64 => "Not an unsigned 64-bit integer",
 			Error::InconsistentMetadata => "Inconsistent metadata",
 			Error::InvalidSectionId(_) =>  "Invalid section id",
+			Error::BufferUnderflow => "Buffer underflow",
 		}
 	}
 }
@@ -197,7 +213,11 @@ pub fn deserialize_file<P: AsRef<::std::path::Path>>(p: P) -> Result<Module, Err
 /// Deserialize deserializable type from buffer.
 pub fn deserialize_buffer<T: Deserialize>(contents: &[u8]) -> Result<T, T::Error> {
 	let mut reader = io::Cursor::new(contents);
-	T::deserialize(&mut reader)
+	let result = T::deserialize(&mut reader)?;
+	if reader.position() != contents.len() as u64 {
+		return Err(T::Error::buffer())
+	}
+	Ok(result)
 }
 
 /// Create buffer with serialized value.

--- a/src/elements/mod.rs
+++ b/src/elements/mod.rs
@@ -123,6 +123,10 @@ pub enum Error {
 	SectionsOutOfOrder,
 	/// Duplicated sections
 	DuplicatedSections(u8),
+	/// Invalid memory reference (should be 0)
+	InvalidMemoryReference(u8),
+	/// Invalid table reference (should be 0)
+	InvalidTableReference(u8),
 }
 
 impl fmt::Display for Error {
@@ -151,6 +155,8 @@ impl fmt::Display for Error {
 			Error::InvalidSectionId(ref id) =>  write!(f, "Invalid section id: {}", id),
 			Error::SectionsOutOfOrder =>  write!(f, "Sections out of order"),
 			Error::DuplicatedSections(ref id) =>  write!(f, "Dupliated sections ({})", id),
+			Error::InvalidMemoryReference(ref mem_ref) =>  write!(f, "Invalid memory reference ({})", mem_ref),
+			Error::InvalidTableReference(ref table_ref) =>  write!(f, "Invalid table reference ({})", table_ref),
 		}
 	}
 }
@@ -179,6 +185,8 @@ impl error::Error for Error {
 			Error::InvalidSectionId(_) =>  "Invalid section id",
 			Error::SectionsOutOfOrder =>  "Sections out of order",
 			Error::DuplicatedSections(_) =>  "Duplicated section",
+			Error::InvalidMemoryReference(_) =>  "Invalid memory reference",
+			Error::InvalidTableReference(_) =>  "Invalid table reference",
 		}
 	}
 }

--- a/src/elements/mod.rs
+++ b/src/elements/mod.rs
@@ -4,6 +4,23 @@ use std::error;
 use std::fmt;
 use std::io;
 
+macro_rules! buffered_read {
+	($buffer_size: expr, $length: expr, $reader: expr) => {
+		{
+			let mut vec_buf = Vec::new();
+			let mut total_read = 0;
+			let mut buf = [0u8; $buffer_size];
+			while total_read < $length {
+				let next_to_read = if $length - total_read > $buffer_size { $buffer_size } else { $length - total_read };
+				$reader.read_exact(&mut buf[0..next_to_read])?;
+				vec_buf.extend_from_slice(&buf[0..next_to_read]);
+				total_read += next_to_read;
+			}
+			vec_buf
+		}
+	}
+}
+
 mod primitives;
 mod module;
 mod section;

--- a/src/elements/mod.rs
+++ b/src/elements/mod.rs
@@ -128,6 +128,8 @@ pub enum Error {
 	InvalidMemoryReference(u8),
 	/// Invalid table reference (should be 0)
 	InvalidTableReference(u8),
+	/// Unknown function form (should be 0x60)
+	UnknownFunctionForm(u8),
 }
 
 impl fmt::Display for Error {
@@ -158,6 +160,7 @@ impl fmt::Display for Error {
 			Error::DuplicatedSections(ref id) =>  write!(f, "Dupliated sections ({})", id),
 			Error::InvalidMemoryReference(ref mem_ref) =>  write!(f, "Invalid memory reference ({})", mem_ref),
 			Error::InvalidTableReference(ref table_ref) =>  write!(f, "Invalid table reference ({})", table_ref),
+			Error::UnknownFunctionForm(ref form) =>  write!(f, "Unknown function form ({})", form),
 		}
 	}
 }
@@ -188,6 +191,7 @@ impl error::Error for Error {
 			Error::DuplicatedSections(_) =>  "Duplicated section",
 			Error::InvalidMemoryReference(_) =>  "Invalid memory reference",
 			Error::InvalidTableReference(_) =>  "Invalid table reference",
+			Error::UnknownFunctionForm(_) =>  "Unknown function form",
 		}
 	}
 }

--- a/src/elements/mod.rs
+++ b/src/elements/mod.rs
@@ -65,7 +65,8 @@ pub trait Deserialize : Sized {
 	fn deserialize<R: io::Read>(reader: &mut R) -> Result<Self, Self::Error>;
 }
 
-/// Serialization to serial i/o
+/// Serialization to serial i/o. Takes self by value to consume less memory
+/// (parity-wasm IR is being partially freed by filling the result buffer).
 pub trait Serialize {
 	/// Serialization error produced by serialization routine.
 	type Error: From<io::Error>;

--- a/src/elements/mod.rs
+++ b/src/elements/mod.rs
@@ -119,6 +119,10 @@ pub enum Error {
 	InconsistentMetadata,
 	/// Invalid section id
 	InvalidSectionId(u8),
+	/// Sections are out of order
+	SectionsOutOfOrder,
+	/// Duplicated sections
+	DuplicatedSections(u8),
 }
 
 impl fmt::Display for Error {
@@ -145,6 +149,8 @@ impl fmt::Display for Error {
 			Error::InvalidVarUint64 => write!(f, "Not an unsigned 64-bit integer"),
 			Error::InconsistentMetadata =>  write!(f, "Inconsistent metadata"),
 			Error::InvalidSectionId(ref id) =>  write!(f, "Invalid section id: {}", id),
+			Error::SectionsOutOfOrder =>  write!(f, "Sections out of order"),
+			Error::DuplicatedSections(ref id) =>  write!(f, "Dupliated sections ({})", id),
 		}
 	}
 }
@@ -171,6 +177,8 @@ impl error::Error for Error {
 			Error::InvalidVarUint64 => "Not an unsigned 64-bit integer",
 			Error::InconsistentMetadata => "Inconsistent metadata",
 			Error::InvalidSectionId(_) =>  "Invalid section id",
+			Error::SectionsOutOfOrder =>  "Sections out of order",
+			Error::DuplicatedSections(_) =>  "Duplicated section",
 		}
 	}
 }

--- a/src/elements/module.rs
+++ b/src/elements/module.rs
@@ -230,11 +230,24 @@ impl Deserialize for Module {
 			return Err(Error::UnsupportedVersion(version));
 		}
 
+		let mut last_section_id = 0;
+
 		loop {
 			match Section::deserialize(reader) {
 				Err(Error::UnexpectedEof) => { break; },
 				Err(e) => { return Err(e) },
-				Ok(section) => { sections.push(section); }
+				Ok(section) => {
+					println!("Section id: {}", section.id());
+					if section.id() != 0 {
+						if last_section_id > section.id() {
+							return Err(Error::SectionsOutOfOrder);
+						} else if last_section_id == section.id() {
+							return Err(Error::DuplicatedSections(last_section_id));
+						}
+					}
+					last_section_id = section.id();
+					sections.push(section);
+				}
 			}
 		}
 

--- a/src/elements/module.rs
+++ b/src/elements/module.rs
@@ -319,7 +319,7 @@ pub fn peek_size(source: &[u8]) -> usize {
 #[cfg(test)]
 mod integration_tests {
 
-	use super::super::{deserialize_file, serialize, deserialize_buffer, Section, Error};
+	use super::super::{deserialize_file, serialize, deserialize_buffer, Section};
 	use super::Module;
 
 	#[test]

--- a/src/elements/module.rs
+++ b/src/elements/module.rs
@@ -237,7 +237,6 @@ impl Deserialize for Module {
 				Err(Error::UnexpectedEof) => { break; },
 				Err(e) => { return Err(e) },
 				Ok(section) => {
-					println!("Section id: {}", section.id());
 					if section.id() != 0 {
 						if last_section_id > section.id() {
 							return Err(Error::SectionsOutOfOrder);

--- a/src/elements/module.rs
+++ b/src/elements/module.rs
@@ -469,15 +469,6 @@ mod integration_tests {
 	}
 
 	#[test]
-	fn inconsistent_meta() {
-		let result = deserialize_file("./res/cases/v1/payload_len.wasm");
-
-		// should be error, not panic
-		if let Err(Error::InconsistentMetadata) = result {}
-		else { panic!("Should return inconsistent metadata error"); }
-	}
-
-	#[test]
 	fn names() {
 		use super::super::name_section::NameSection;
 

--- a/src/elements/ops.rs
+++ b/src/elements/ops.rs
@@ -344,9 +344,16 @@ impl Deserialize for Opcode {
 				},
 				0x0f => Return,
 				0x10 => Call(VarUint32::deserialize(reader)?.into()),
-				0x11 => CallIndirect(
-					VarUint32::deserialize(reader)?.into(),
-					Uint8::deserialize(reader)?.into()),
+				0x11 => {
+					let signature: u32 = VarUint32::deserialize(reader)?.into();
+					let table_ref: u8 = Uint8::deserialize(reader)?.into();
+					if table_ref != 0 { return Err(Error::InvalidTableReference(table_ref)); }
+
+					CallIndirect(
+						signature,
+						table_ref,
+					)
+				},
 				0x1a => Drop,
 				0x1b => Select,
 
@@ -449,8 +456,16 @@ impl Deserialize for Opcode {
 					VarUint32::deserialize(reader)?.into()),
 
 
-				0x3f => CurrentMemory(Uint8::deserialize(reader)?.into()),
-				0x40 => GrowMemory(Uint8::deserialize(reader)?.into()),
+				0x3f => {
+					let mem_ref: u8 = Uint8::deserialize(reader)?.into();
+					if mem_ref != 0 { return Err(Error::InvalidMemoryReference(mem_ref)); }
+					CurrentMemory(mem_ref)
+				},
+				0x40 => {
+					let mem_ref: u8 = Uint8::deserialize(reader)?.into();
+					if mem_ref != 0 { return Err(Error::InvalidMemoryReference(mem_ref)); }
+					GrowMemory(mem_ref)
+				}
 
 				0x41 => I32Const(VarInt32::deserialize(reader)?.into()),
 				0x42 => I64Const(VarInt64::deserialize(reader)?.into()),

--- a/src/elements/primitives.rs
+++ b/src/elements/primitives.rs
@@ -2,23 +2,6 @@ use std::io;
 use byteorder::{LittleEndian, ByteOrder};
 use super::{Error, Deserialize, Serialize};
 
-macro_rules! buffered_read {
-	($buffer_size: expr, $length: expr, $reader: expr) => {
-		{
-			let mut vec_buf = Vec::new();
-			let mut total_read = 0;
-			let mut buf = [0u8; $buffer_size];
-			while total_read < $length {
-				let next_to_read = if $length - total_read > $buffer_size { $buffer_size } else { $length - total_read };
-				$reader.read_exact(&mut buf[0..next_to_read])?;
-				vec_buf.extend_from_slice(&buf[0..next_to_read]);
-				total_read += next_to_read;
-			}
-			vec_buf
-		}
-	}
-}
-
 /// Unsigned variable-length integer, limited to 32 bits,
 /// represented by at most 5 bytes that may contain padding 0x80 bytes.
 #[derive(Debug, Copy, Clone)]

--- a/src/elements/section.rs
+++ b/src/elements/section.rs
@@ -195,6 +195,27 @@ impl Serialize for Section {
 	}
 }
 
+impl Section {
+	pub(crate) fn id(&self) -> u8 {
+		match *self {
+			Section::Custom(_) => 0x00,
+			Section::Unparsed { .. } => 0x00,
+			Section::Type(_) => 0x1,
+			Section::Import(_) => 0x2,
+			Section::Function(_) => 0x3,
+			Section::Table(_) => 0x4,
+			Section::Memory(_) => 0x5,
+			Section::Global(_) => 0x6,
+			Section::Export(_) => 0x7,
+			Section::Start(_) => 0x8,
+			Section::Element(_) => 0x9,
+			Section::Code(_) => 0x0a,
+			Section::Data(_) => 0x0b,
+			Section::Name(_) => 0x00,
+		}
+	}
+}
+
 fn read_entries<R: io::Read, T: Deserialize<Error=::elements::Error>>(
 	reader: &mut R,
 	defined_length: usize,

--- a/src/elements/section.rs
+++ b/src/elements/section.rs
@@ -844,7 +844,7 @@ mod tests {
 
 			// func 2, form=1
 			0x01,
-			// param_count=1
+			// param_count=2
 			2,
 				// first param
 				0x7e,
@@ -961,7 +961,7 @@ mod tests {
 	fn data_payload() -> &'static [u8] {
 		&[
 			0x0bu8,  // section id
-			20,      // 19 bytes overall
+			20,      // 20 bytes overall
 			0x01,    // number of segments
 			0x00,    // index
 			0x0b,    // just `end` op

--- a/src/elements/section.rs
+++ b/src/elements/section.rs
@@ -2,7 +2,6 @@ use std::io;
 use super::{
 	Serialize,
 	Deserialize,
-	Unparsed,
 	Error,
 	VarUint7,
 	VarUint32,
@@ -114,9 +113,9 @@ impl Deserialize for Section {
 				11 => {
 					Section::Data(DataSection::deserialize(reader)?)
 				},
-				_ => {
-					Section::Unparsed { id: id.into(), payload: Unparsed::deserialize(reader)?.into() }
-				}
+				invalid_id => {
+					return Err(Error::InvalidSectionId(invalid_id))
+				},
 			}
 		)
 	}

--- a/src/elements/section.rs
+++ b/src/elements/section.rs
@@ -238,9 +238,17 @@ impl Deserialize for CustomSection {
 			return Ok(CustomSection { name: name, payload: Vec::new() });
 		}
 
-		let payload_left = section_length - total_naming;
-		let mut payload = vec![0u8; payload_left as usize];
-		reader.read_exact(&mut payload[..])?;
+		let payload_left = section_length as usize - total_naming as usize;
+		let mut payload = Vec::new();
+
+		let mut total_read = 0;
+		let mut buf = [0u8; 65536];
+		while total_read < payload_left {
+			let next_to_read = if payload_left - total_read > 65536 { 65536 } else { payload_left - total_read };
+			reader.read_exact(&mut buf[0..next_to_read])?;
+			payload.extend_from_slice(&buf[0..next_to_read]);
+			total_read += next_to_read;
+		}
 
 		Ok(CustomSection { name: name, payload: payload })
 	}

--- a/src/elements/section.rs
+++ b/src/elements/section.rs
@@ -873,14 +873,14 @@ mod tests {
 	fn types_test_payload() -> &'static [u8] {
 		&[
 			// section length
-			148u8, 0x80, 0x80, 0x80, 0x0,
+			11,
 
 			// 2 functions
-			130u8, 0x80, 0x80, 0x80, 0x0,
+			2,
 			// func 1, form =1
 			0x01,
 			// param_count=1
-			129u8, 0x80, 0x80, 0x80, 0x0,
+			1,
 				// first param
 				0x7e, // i64
 			// no return params
@@ -889,7 +889,7 @@ mod tests {
 			// func 2, form=1
 			0x01,
 			// param_count=1
-			130u8, 0x80, 0x80, 0x80, 0x0,
+			2,
 				// first param
 				0x7e,
 				// second param
@@ -925,9 +925,9 @@ mod tests {
 			// section id
 			0x07,
 			// section length
-			148u8, 0x80, 0x80, 0x80, 0x0,
+			28,
 			// 6 entries
-			134u8, 0x80, 0x80, 0x80, 0x0,
+			6,
 			// func "A", index 6
 			// [name_len(1-5 bytes), name_bytes(name_len, internal_kind(1byte), internal_index(1-5 bytes)])
 			0x01, 0x41,  0x01, 0x86, 0x80, 0x00,
@@ -1005,10 +1005,11 @@ mod tests {
 	fn data_payload() -> &'static [u8] {
 		&[
 			0x0bu8,  // section id
-			19,      // 19 bytes overall
+			20,      // 19 bytes overall
 			0x01,    // number of segments
 			0x00,    // index
 			0x0b,    // just `end` op
+			0x10,
 			// 16x 0x00
 			0x00, 0x00, 0x00, 0x00,
 			0x00, 0x00, 0x00, 0x00,

--- a/src/elements/section.rs
+++ b/src/elements/section.rs
@@ -293,10 +293,13 @@ impl Deserialize for TypeSection {
 	type Error = Error;
 
 	fn deserialize<R: io::Read>(reader: &mut R) -> Result<Self, Self::Error> {
-		// todo: maybe use reader.take(section_length)
-		let _section_length = VarUint32::deserialize(reader)?;
-		let types: Vec<Type> = CountedList::deserialize(reader)?.into_inner();
-		Ok(TypeSection(types))
+		use std::io::Read;
+		let section_length = u32::from(VarUint32::deserialize(reader)?) as u64;
+		Ok(
+			TypeSection(CountedList::<Type>::deserialize(
+				&mut reader.by_ref().take(section_length)
+			)?.into_inner())
+		)
 	}
 }
 
@@ -355,10 +358,12 @@ impl Deserialize for ImportSection {
 	type Error = Error;
 
 	fn deserialize<R: io::Read>(reader: &mut R) -> Result<Self, Self::Error> {
-		// todo: maybe use reader.take(section_length)
-		let _section_length = VarUint32::deserialize(reader)?;
-		let entries: Vec<ImportEntry> = CountedList::deserialize(reader)?.into_inner();
-		Ok(ImportSection(entries))
+		use std::io::Read;
+		let section_length = u32::from(VarUint32::deserialize(reader)?) as u64;
+
+		Ok(ImportSection(
+			CountedList::<ImportEntry>::deserialize(&mut reader.by_ref().take(section_length))?.into_inner()
+		))
 	}
 }
 
@@ -403,11 +408,12 @@ impl Deserialize for FunctionSection {
 	type Error = Error;
 
 	fn deserialize<R: io::Read>(reader: &mut R) -> Result<Self, Self::Error> {
-		// todo: maybe use reader.take(section_length)
-		let _section_length = VarUint32::deserialize(reader)?;
-		let funcs: Vec<Func> = CountedList::<Func>::deserialize(reader)?
-			.into_inner();
-		Ok(FunctionSection(funcs))
+		use std::io::Read;
+		let section_length = u32::from(VarUint32::deserialize(reader)?) as u64;
+
+		Ok(FunctionSection(
+			CountedList::<Func>::deserialize(&mut reader.by_ref().take(section_length))?.into_inner()
+		))
 	}
 }
 
@@ -452,10 +458,12 @@ impl Deserialize for TableSection {
 	type Error = Error;
 
 	fn deserialize<R: io::Read>(reader: &mut R) -> Result<Self, Self::Error> {
-		// todo: maybe use reader.take(section_length)
-		let _section_length = VarUint32::deserialize(reader)?;
-		let entries: Vec<TableType> = CountedList::deserialize(reader)?.into_inner();
-		Ok(TableSection(entries))
+		use std::io::Read;
+		let section_length = u32::from(VarUint32::deserialize(reader)?) as u64;
+
+		Ok(TableSection(
+			CountedList::<TableType>::deserialize(&mut reader.by_ref().take(section_length))?.into_inner()
+		))
 	}
 }
 
@@ -500,10 +508,12 @@ impl Deserialize for MemorySection {
 	type Error = Error;
 
 	fn deserialize<R: io::Read>(reader: &mut R) -> Result<Self, Self::Error> {
-		// todo: maybe use reader.take(section_length)
-		let _section_length = VarUint32::deserialize(reader)?;
-		let entries: Vec<MemoryType> = CountedList::deserialize(reader)?.into_inner();
-		Ok(MemorySection(entries))
+		use std::io::Read;
+		let section_length = u32::from(VarUint32::deserialize(reader)?) as u64;
+
+		Ok(MemorySection(
+			CountedList::<MemoryType>::deserialize(&mut reader.by_ref().take(section_length))?.into_inner()
+		))
 	}
 }
 
@@ -548,10 +558,12 @@ impl Deserialize for GlobalSection {
 	type Error = Error;
 
 	fn deserialize<R: io::Read>(reader: &mut R) -> Result<Self, Self::Error> {
-		// todo: maybe use reader.take(section_length)
-		let _section_length = VarUint32::deserialize(reader)?;
-		let entries: Vec<GlobalEntry> = CountedList::deserialize(reader)?.into_inner();
-		Ok(GlobalSection(entries))
+		use std::io::Read;
+		let section_length = u32::from(VarUint32::deserialize(reader)?) as u64;
+
+		Ok(GlobalSection(
+			CountedList::<GlobalEntry>::deserialize(&mut reader.by_ref().take(section_length))?.into_inner()
+		))
 	}
 }
 
@@ -596,10 +608,12 @@ impl Deserialize for ExportSection {
 	type Error = Error;
 
 	fn deserialize<R: io::Read>(reader: &mut R) -> Result<Self, Self::Error> {
-		// todo: maybe use reader.take(section_length)
-		let _section_length = VarUint32::deserialize(reader)?;
-		let entries: Vec<ExportEntry> = CountedList::deserialize(reader)?.into_inner();
-		Ok(ExportSection(entries))
+		use std::io::Read;
+		let section_length = u32::from(VarUint32::deserialize(reader)?) as u64;
+
+		Ok(ExportSection(
+			CountedList::<ExportEntry>::deserialize(&mut reader.by_ref().take(section_length))?.into_inner()
+		))
 	}
 }
 
@@ -644,10 +658,12 @@ impl Deserialize for CodeSection {
 	type Error = Error;
 
 	fn deserialize<R: io::Read>(reader: &mut R) -> Result<Self, Self::Error> {
-		// todo: maybe use reader.take(section_length)
-		let _section_length = VarUint32::deserialize(reader)?;
-		let entries: Vec<FuncBody> = CountedList::deserialize(reader)?.into_inner();
-		Ok(CodeSection(entries))
+		use std::io::Read;
+		let section_length = u32::from(VarUint32::deserialize(reader)?) as u64;
+
+		Ok(CodeSection(
+			CountedList::<FuncBody>::deserialize(&mut reader.by_ref().take(section_length))?.into_inner()
+		))
 	}
 }
 
@@ -692,10 +708,12 @@ impl Deserialize for ElementSection {
 	type Error = Error;
 
 	fn deserialize<R: io::Read>(reader: &mut R) -> Result<Self, Self::Error> {
-		// todo: maybe use reader.take(section_length)
-		let _section_length = VarUint32::deserialize(reader)?;
-		let entries: Vec<ElementSegment> = CountedList::deserialize(reader)?.into_inner();
-		Ok(ElementSection(entries))
+		use std::io::Read;
+		let section_length = u32::from(VarUint32::deserialize(reader)?) as u64;
+
+		Ok(ElementSection(
+			CountedList::<ElementSegment>::deserialize(&mut reader.by_ref().take(section_length))?.into_inner()
+		))
 	}
 }
 
@@ -740,10 +758,12 @@ impl Deserialize for DataSection {
 	type Error = Error;
 
 	fn deserialize<R: io::Read>(reader: &mut R) -> Result<Self, Self::Error> {
-		// todo: maybe use reader.take(section_length)
-		let _section_length = VarUint32::deserialize(reader)?;
-		let entries: Vec<DataSegment> = CountedList::deserialize(reader)?.into_inner();
-		Ok(DataSection(entries))
+		use std::io::Read;
+		let section_length = u32::from(VarUint32::deserialize(reader)?) as u64;
+
+		Ok(DataSection(
+			CountedList::<DataSegment>::deserialize(&mut reader.by_ref().take(section_length))?.into_inner()
+		))
 	}
 }
 

--- a/src/elements/section.rs
+++ b/src/elements/section.rs
@@ -855,7 +855,7 @@ mod tests {
 			// 2 functions
 			2,
 			// func 1, form =1
-			0x01,
+			0x60,
 			// param_count=1
 			1,
 				// first param
@@ -864,7 +864,7 @@ mod tests {
 			0x00,
 
 			// func 2, form=1
-			0x01,
+			0x60,
 			// param_count=2
 			2,
 				// first param

--- a/src/elements/segment.rs
+++ b/src/elements/segment.rs
@@ -108,16 +108,7 @@ impl Deserialize for DataSegment {
 		let index = VarUint32::deserialize(reader)?;
 		let offset = InitExpr::deserialize(reader)?;
 		let value_len = u32::from(VarUint32::deserialize(reader)?) as usize;
-
-		let mut value_buf = Vec::new();
-		let mut total_read = 0;
-		let mut buf = [0u8; 65536];
-		while total_read < value_len {
-			let next_to_read = if value_len - total_read > 65536 { 65536 } else { value_len - total_read };
-			reader.read_exact(&mut buf[0..next_to_read])?;
-			value_buf.extend_from_slice(&buf[0..next_to_read]);
-			total_read += next_to_read;
-		}
+		let value_buf = buffered_read!(65546, value_len, reader);
 
 		Ok(DataSegment {
 			index: index.into(),

--- a/src/elements/segment.rs
+++ b/src/elements/segment.rs
@@ -108,7 +108,7 @@ impl Deserialize for DataSegment {
 		let index = VarUint32::deserialize(reader)?;
 		let offset = InitExpr::deserialize(reader)?;
 		let value_len = u32::from(VarUint32::deserialize(reader)?) as usize;
-		let value_buf = buffered_read!(65546, value_len, reader);
+		let value_buf = buffered_read!(65536, value_len, reader);
 
 		Ok(DataSegment {
 			index: index.into(),

--- a/src/elements/types.rs
+++ b/src/elements/types.rs
@@ -171,6 +171,10 @@ impl Deserialize for FunctionType {
 	fn deserialize<R: io::Read>(reader: &mut R) -> Result<Self, Self::Error> {
 		let form: u8 = VarUint7::deserialize(reader)?.into();
 
+		if form != 0x60 {
+			return Err(Error::UnknownFunctionForm(form));
+		}
+
 		let params: Vec<ValueType> = CountedList::deserialize(reader)?.into_inner();
 
 		let has_return_type = VarUint1::deserialize(reader)?;


### PR DESCRIPTION
- Fix the situation when section declared length N, but the content inside section was of length M != N
- Fix the situation when section declared length N, while the module leftover for this section is just M
- Fix all occurrences of  allocations with size read from payload, which lead to enormous allocations 
- Error on out-of-order and duplicate sections
- Checks if all reserved fields are zeroed
- Fix the situation when declared function body length is N while code takes the length of M != N