### PR TITLE
add more PartialEq for testing

### DIFF
--- a/src/builder/memory.rs
+++ b/src/builder/memory.rs
@@ -2,7 +2,7 @@ use elements;
 use super::invoke::{Invoke, Identity};
 
 /// Memory definition struct
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct MemoryDefinition {
 	/// Minimum memory size
 	pub min: u32,
@@ -13,7 +13,7 @@ pub struct MemoryDefinition {
 }
 
 /// Memory static region entry definition
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct MemoryDataDefinition {
 	/// Segment initialization expression for offset
 	pub offset: elements::InitExpr,

--- a/src/builder/module.rs
+++ b/src/builder/module.rs
@@ -19,7 +19,7 @@ pub struct CodeLocation {
 	pub body: u32,
 }
 
-#[derive(Default)]
+#[derive(Default, PartialEq)]
 struct ModuleScaffold {
 	pub types: elements::TypeSection,
 	pub import: elements::ImportSection,

--- a/src/builder/table.rs
+++ b/src/builder/table.rs
@@ -2,7 +2,7 @@ use elements;
 use super::invoke::{Invoke, Identity};
 
 /// Table definition
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct TableDefinition {
 	/// Minimum length
 	pub min: u32,
@@ -13,7 +13,7 @@ pub struct TableDefinition {
 }
 
 /// Table elements entry definition
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct TableEntryDefinition {
 	/// Offset initialization expression
 	pub offset: elements::InitExpr,

--- a/src/elements/export_entry.rs
+++ b/src/elements/export_entry.rs
@@ -2,7 +2,7 @@ use std::io;
 use super::{Deserialize, Serialize, Error, VarUint7, VarUint32};
 
 /// Internal reference of the exported entry.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Internal {
 	/// Function reference.
 	Function(u32),
@@ -48,7 +48,7 @@ impl Serialize for Internal {
 }
 
 /// Export entry.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ExportEntry {
 	field_str: String,
 	internal: Internal,

--- a/src/elements/func.rs
+++ b/src/elements/func.rs
@@ -6,7 +6,7 @@ use super::{
 use elements::section::SectionReader;
 
 /// Function signature (type reference)
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub struct Func(u32);
 
 impl Func {
@@ -41,7 +41,7 @@ impl Deserialize for Func {
 }
 
 /// Local definition inside the function body.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub struct Local {
 	count: u32,
 	value_type: ValueType,
@@ -81,7 +81,7 @@ impl Serialize for Local {
 }
 
 /// Function body definition.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct FuncBody {
 	locals: Vec<Local>,
 	opcodes: Opcodes,

--- a/src/elements/global_entry.rs
+++ b/src/elements/global_entry.rs
@@ -2,7 +2,7 @@ use std::io;
 use super::{Deserialize, Serialize, Error, GlobalType, InitExpr};
 
 /// Global entry in the module.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct GlobalEntry {
 	global_type: GlobalType,
 	init_expr: InitExpr,

--- a/src/elements/import_entry.rs
+++ b/src/elements/import_entry.rs
@@ -5,7 +5,7 @@ use super::{
 };
 
 /// Global definition struct
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub struct GlobalType {
 	content_type: ValueType,
 	is_mutable: bool,
@@ -51,7 +51,7 @@ impl Serialize for GlobalType {
 }
 
 /// Table entry
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub struct TableType {
 	elem_type: TableElementType,
 	limits: ResizableLimits,
@@ -96,7 +96,7 @@ impl Serialize for TableType {
 }
 
 /// Memory limits
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ResizableLimits {
 	initial: u32,
 	maximum: Option<u32>,
@@ -150,7 +150,7 @@ impl Serialize for ResizableLimits {
 }
 
 /// Memory entry.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub struct MemoryType(ResizableLimits);
 
 impl MemoryType {
@@ -181,7 +181,7 @@ impl Serialize for MemoryType {
 }
 
 /// External to local binding.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub enum External {
 	/// Binds to function with index.
 	Function(u32),
@@ -238,7 +238,7 @@ impl Serialize for External {
 }
 
 /// Import entry.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ImportEntry {
 	module_str: String,
 	field_str: String,

--- a/src/elements/module.rs
+++ b/src/elements/module.rs
@@ -12,14 +12,14 @@ use super::reloc_section::RelocSection;
 const WASM_MAGIC_NUMBER: [u8; 4] = [0x00, 0x61, 0x73, 0x6d];
 
 /// WebAssembly module
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Module {
 	magic: u32,
 	version: u32,
 	sections: Vec<Section>,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 /// Type of the import entry to count
 pub enum ImportCountType {
 	/// Count functions
@@ -440,7 +440,7 @@ impl Serialize for Module {
 	}
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 struct PeekSection<'a> {
 	cursor: usize,
 	region: &'a [u8],

--- a/src/elements/ops.rs
+++ b/src/elements/ops.rs
@@ -7,7 +7,7 @@ use super::{
 };
 
 /// Collection of opcodes (usually inside a block section).
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Opcodes(Vec<Opcode>);
 
 impl Opcodes {
@@ -54,7 +54,7 @@ impl Deserialize for Opcodes {
 }
 
 /// Initialization expression.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct InitExpr(Vec<Opcode>);
 
 impl InitExpr {

--- a/src/elements/primitives.rs
+++ b/src/elements/primitives.rs
@@ -4,7 +4,7 @@ use super::{Error, Deserialize, Serialize};
 
 /// Unsigned variable-length integer, limited to 32 bits,
 /// represented by at most 5 bytes that may contain padding 0x80 bytes.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub struct VarUint32(u32);
 
 impl From<VarUint32> for usize {
@@ -79,7 +79,7 @@ impl Serialize for VarUint32 {
 
 /// Unsigned variable-length integer, limited to 64 bits,
 /// represented by at most 9 bytes that may contain padding 0x80 bytes.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub struct VarUint64(u64);
 
 impl From<VarUint64> for u64 {
@@ -140,7 +140,7 @@ impl From<u64> for VarUint64 {
 }
 
 /// 7-bit unsigned integer, encoded in LEB128 (always 1 byte length)
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub struct VarUint7(u8);
 
 impl From<VarUint7> for u8 {
@@ -176,7 +176,7 @@ impl Serialize for VarUint7 {
 }
 
 /// 7-bit signed integer, encoded in LEB128 (always 1 byte length)
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub struct VarInt7(i8);
 
 impl From<VarInt7> for i8 {
@@ -224,7 +224,7 @@ impl Serialize for VarInt7 {
 
 /// 8-bit unsigned integer, NOT encoded in LEB128;
 /// it's just a single byte.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub struct Uint8(u8);
 
 impl From<Uint8> for u8 {
@@ -260,7 +260,7 @@ impl Serialize for Uint8 {
 
 
 /// 32-bit signed integer, encoded in LEB128 (can be 1-5 bytes length)
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub struct VarInt32(i32);
 
 impl From<VarInt32> for i32 {
@@ -333,7 +333,7 @@ impl Serialize for VarInt32 {
 }
 
 /// 64-bit signed integer, encoded in LEB128 (can be 1-9 bytes length)
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub struct VarInt64(i64);
 
 impl From<VarInt64> for i64 {
@@ -405,7 +405,7 @@ impl Serialize for VarInt64 {
 }
 
 /// 32-bit unsigned integer, encoded in little endian
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub struct Uint32(u32);
 
 impl Deserialize for Uint32 {
@@ -441,7 +441,7 @@ impl From<u32> for Uint32 {
 }
 
 /// 64-bit unsigned integer, encoded in little endian
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub struct Uint64(u64);
 
 impl Deserialize for Uint64 {
@@ -478,7 +478,7 @@ impl From<Uint64> for u64 {
 
 
 /// VarUint1, 1-bit value (0/1)
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub struct VarUint1(bool);
 
 impl From<VarUint1> for bool {

--- a/src/elements/reloc_section.rs
+++ b/src/elements/reloc_section.rs
@@ -12,7 +12,7 @@ const TYPE_INDEX_LEB: u8 = 6;
 const GLOBAL_INDEX_LEB: u8 = 7;
 
 /// Relocation information.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct RelocSection {
 	/// Name of this section.
 	name: String,

--- a/src/elements/section.rs
+++ b/src/elements/section.rs
@@ -28,7 +28,7 @@ use super::reloc_section::RelocSection;
 const ENTRIES_BUFFER_LENGTH: usize = 16384;
 
 /// Section in the WebAssembly module.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Section {
 	/// Section is unparsed.
 	Unparsed {
@@ -276,7 +276,7 @@ fn read_entries<R: io::Read, T: Deserialize<Error=::elements::Error>>(reader: &m
 }
 
 /// Custom section
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, PartialEq)]
 pub struct CustomSection {
 	name: String,
 	payload: Vec<u8>,
@@ -333,7 +333,7 @@ impl Serialize for CustomSection {
 }
 
 /// Section with type declarations
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, PartialEq)]
 pub struct TypeSection(Vec<Type>);
 
 impl TypeSection {
@@ -378,7 +378,7 @@ impl Serialize for TypeSection {
 }
 
 /// Section of the imports definition.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, PartialEq)]
 pub struct ImportSection(Vec<ImportEntry>);
 
 impl ImportSection {
@@ -437,7 +437,7 @@ impl Serialize for ImportSection {
 }
 
 /// Section with function signatures definition.
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct FunctionSection(Vec<Func>);
 
 impl FunctionSection {
@@ -482,7 +482,7 @@ impl Serialize for FunctionSection {
 }
 
 /// Section with table definition (currently only one is allowed).
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct TableSection(Vec<TableType>);
 
 impl TableSection {
@@ -527,7 +527,7 @@ impl Serialize for TableSection {
 }
 
 /// Section with table definition (currently only one entry is allowed).
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct MemorySection(Vec<MemoryType>);
 
 impl MemorySection {
@@ -572,7 +572,7 @@ impl Serialize for MemorySection {
 }
 
 /// Globals definition section.
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GlobalSection(Vec<GlobalEntry>);
 
 impl GlobalSection {
@@ -617,7 +617,7 @@ impl Serialize for GlobalSection {
 }
 
 /// List of exports definition.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, PartialEq)]
 pub struct ExportSection(Vec<ExportEntry>);
 
 impl ExportSection {
@@ -662,7 +662,7 @@ impl Serialize for ExportSection {
 }
 
 /// Section with function bodies of the module.
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CodeSection(Vec<FuncBody>);
 
 impl CodeSection {
@@ -707,7 +707,7 @@ impl Serialize for CodeSection {
 }
 
 /// Element entries section.
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ElementSection(Vec<ElementSegment>);
 
 impl ElementSection {
@@ -752,7 +752,7 @@ impl Serialize for ElementSection {
 }
 
 /// Data entries definitions.
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DataSection(Vec<DataSegment>);
 
 impl DataSection {

--- a/src/elements/segment.rs
+++ b/src/elements/segment.rs
@@ -2,7 +2,7 @@ use std::io;
 use super::{Deserialize, Serialize, Error, VarUint32, CountedList, InitExpr, CountedListWriter};
 
 /// Entry in the element section.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ElementSegment {
 	index: u32,
 	offset: InitExpr,
@@ -68,7 +68,7 @@ impl Serialize for ElementSegment {
 }
 
 /// Data segment definition.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct DataSegment {
 	index: u32,
 	offset: InitExpr,

--- a/src/elements/types.rs
+++ b/src/elements/types.rs
@@ -5,7 +5,7 @@ use super::{
 };
 
 /// Type definition in types section. Currently can be only of the function type.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Type {
 	/// Function type.
 	Function(FunctionType),
@@ -30,7 +30,7 @@ impl Serialize for Type {
 }
 
 /// Value type.
-#[derive(Clone, Copy, PartialEq, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ValueType {
 	/// 32-bit signed integer
 	I32,
@@ -85,7 +85,7 @@ impl fmt::Display for ValueType {
 }
 
 /// Block type which is basically `ValueType` + NoResult (to define blocks that have no return type)
-#[derive(Clone, Copy, PartialEq, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum BlockType {
 	/// Value-type specified block type
 	Value(ValueType),
@@ -220,7 +220,7 @@ impl Serialize for FunctionType {
 }
 
 /// Table element type.
-#[derive(Clone, Copy, PartialEq, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum TableElementType {
 	/// A reference to a function with any signature.
 	AnyFunc,


### PR DESCRIPTION
I'm working on [a WAST parser prototype](https://github.com/flier/rust-wast) and plan to compile it to WASM with `parity-wasm`, and need `impl PartialEq` for those internal types for testing.