### PR TITLE
Update the testsuite

### DIFF
--- a/spec/Cargo.toml
+++ b/spec/Cargo.toml
@@ -9,5 +9,5 @@ homepage = "https://github.com/nikvolf/parity-wasm"
 description = "parity-wasm testsuite"
 
 [dependencies]
-wabt = "0.6"
+wabt = "0.7.1"
 parity-wasm = { path = ".." }

--- a/spec/src/run.rs
+++ b/spec/src/run.rs
@@ -23,7 +23,7 @@ pub fn spec(path: &str) {
 		match kind {
 			CommandKind::AssertMalformed { module, .. } => {
 				match deserialize_buffer::<Module>(&module.into_vec()) {
-					Ok(_) => panic!("Expected invalid module definition, got some module!"),
+					Ok(_) => panic!("Expected invalid module definition, got some module! at line {}", line),
 					Err(e) => println!("assert_invalid at line {} - success ({:?})", line, e),
 				}
 			}

--- a/src/elements/mod.rs
+++ b/src/elements/mod.rs
@@ -145,6 +145,8 @@ pub enum Error {
 	InconsistentCode,
 	/// Only flags 0, 1, and 2 are accepted on segments
 	InvalidSegmentFlags(u32),
+	/// Sum of counts of locals is greater than 2^32.
+	TooManyLocals,
 }
 
 impl fmt::Display for Error {
@@ -181,6 +183,7 @@ impl fmt::Display for Error {
 			Error::UnknownFunctionForm(ref form) =>  write!(f, "Unknown function form ({})", form),
 			Error::InconsistentCode =>  write!(f, "Number of function body entries and signatures does not match"),
 			Error::InvalidSegmentFlags(n) =>  write!(f, "Invalid segment flags: {}", n),
+			Error::TooManyLocals => write!(f, "Too many locals"),
 		}
 	}
 }
@@ -218,6 +221,7 @@ impl ::std::error::Error for Error {
 			Error::UnknownFunctionForm(_) =>  "Unknown function form",
 			Error::InconsistentCode =>  "Number of function body entries and signatures does not match",
 			Error::InvalidSegmentFlags(_) =>  "Invalid segment flags",
+			Error::TooManyLocals => "Too many locals",
 		}
 	}
 }


### PR DESCRIPTION
There was one minor problem. The specification disallows more than 2³² locals per one function. This case was already handled in wasmi validation, but it turned out that this check should be performed at binary decoding level. This PR introduces this check.

Closes #242 