### PR TITLE
Add possibility to use enum Instruction in hash structures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ Cargo.lock
 .vscode
 **/.DS_Store
 rls
+.idea

--- a/src/elements/ops.rs
+++ b/src/elements/ops.rs
@@ -104,7 +104,7 @@ impl Deserialize for InitExpr {
 }
 
 /// Instruction.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[allow(missing_docs)]
 pub enum Instruction {
 	Unreachable,
@@ -539,14 +539,14 @@ pub enum Instruction {
 	TableCopy,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[allow(missing_docs)]
 pub struct MemArg {
 	pub align: u8,
 	pub offset: u32,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[allow(missing_docs)]
 pub struct BrTableData {
 	pub table: Box<[u32]>,
@@ -2779,4 +2779,14 @@ fn display() {
 #[test]
 fn size_off() {
 	assert!(::std::mem::size_of::<Instruction>() <= 24);
+}
+
+#[test]
+fn instructions_hashset() {
+	use self::Instruction::{Call, Block, Drop};
+	use super::types::{BlockType::Value, ValueType};
+
+	let set: std::collections::HashSet<Instruction> =
+		vec![Call(1), Block(Value(ValueType::I32)), Drop].into_iter().collect();
+	assert_eq!(set.contains(&Drop), true)
 }

--- a/src/elements/types.rs
+++ b/src/elements/types.rs
@@ -92,7 +92,7 @@ impl fmt::Display for ValueType {
 }
 
 /// Block type which is basically `ValueType` + NoResult (to define blocks that have no return type)
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum BlockType {
 	/// Value-type specified block type
 	Value(ValueType),


### PR DESCRIPTION
Hi folks! 
Sometimes you need to find all specific instructions in a function like this
```rust
let instruction_set: HashSet<Instruction> = ...
module.code_section().unwrap().bodies().iter()
    .filter(move |ins| {instruction_set.contains(&ins)})
    ....
```
Let's allow enum 'Instruction' to implement 'Eq'  and 'Hash'. What do you think?