### PR TITLE
Remove byteorder dependency, use std lib for dealing with endianness

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,9 @@ keywords = ["wasm", "webassembly", "bytecode", "serde", "interpreter"]
 categories = ["wasm", "parser-implementations"]
 exclude = [ "res/*", "spec/*" ]
 
-[dependencies]
-byteorder = { version = "1.0", default-features = false }
-
 [dev-dependencies]
 time = "0.1"
 
 [features]
 default = ["std"]
-std = ["byteorder/std"]
+std = []

--- a/src/elements/module.rs
+++ b/src/elements/module.rs
@@ -2,7 +2,6 @@ use io;
 use std::vec::Vec;
 use std::borrow::ToOwned;
 use std::string::String;
-use byteorder::{LittleEndian, ByteOrder};
 
 use super::{Deserialize, Serialize, Error, Uint32, External};
 use super::section::{
@@ -39,7 +38,7 @@ pub enum ImportCountType {
 impl Default for Module {
 	fn default() -> Self {
 		Module {
-			magic: LittleEndian::read_u32(&WASM_MAGIC_NUMBER),
+			magic: u32::from_le_bytes(WASM_MAGIC_NUMBER),
 			version: 1,
 			sections: Vec::with_capacity(16),
 		}
@@ -504,7 +503,7 @@ impl Deserialize for Module {
 		}
 
 		let module = Module {
-			magic: LittleEndian::read_u32(&magic),
+			magic: u32::from_le_bytes(magic),
 			version: version,
 			sections: sections,
 		};

--- a/src/elements/primitives.rs
+++ b/src/elements/primitives.rs
@@ -1,7 +1,6 @@
 use io;
 use std::vec::Vec;
 use std::string::String;
-use byteorder::{LittleEndian, ByteOrder};
 use super::{Error, Deserialize, Serialize};
 
 /// Unsigned variable-length integer, limited to 32 bits,
@@ -417,7 +416,7 @@ impl Deserialize for Uint32 {
 		let mut buf = [0u8; 4];
 		reader.read(&mut buf)?;
 		// todo check range
-		Ok(Uint32(LittleEndian::read_u32(&buf)))
+		Ok(u32::from_le_bytes(buf).into())
 	}
 }
 
@@ -431,9 +430,7 @@ impl Serialize for Uint32 {
 	type Error = Error;
 
 	fn serialize<W: io::Write>(self, writer: &mut W) -> Result<(), Self::Error> {
-		let mut buf = [0u8; 4];
-		LittleEndian::write_u32(&mut buf, self.0);
-		writer.write(&buf)?;
+		writer.write(&self.0.to_le_bytes())?;
 		Ok(())
 	}
 }
@@ -453,7 +450,7 @@ impl Deserialize for Uint64 {
 		let mut buf = [0u8; 8];
 		reader.read(&mut buf)?;
 		// todo check range
-		Ok(Uint64(LittleEndian::read_u64(&buf)))
+		Ok(u64::from_le_bytes(buf).into())
 	}
 }
 
@@ -461,9 +458,7 @@ impl Serialize for Uint64 {
 	type Error = Error;
 
 	fn serialize<W: io::Write>(self, writer: &mut W) -> Result<(), Self::Error> {
-		let mut buf = [0u8; 8];
-		LittleEndian::write_u64(&mut buf, self.0);
-		writer.write(&buf)?;
+		writer.write(&self.0.to_le_bytes())?;
 		Ok(())
 	}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,8 +5,6 @@
 
 #![warn(missing_docs)]
 
-extern crate byteorder;
-
 #[cfg(not(feature = "std"))]
 #[macro_use]
 extern crate alloc;


### PR DESCRIPTION
Now zero dependencies :)