### PR TITLE
Featurize non-MVP features

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ script:
 - export CXX=/usr/bin/g++-8
 - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then cargo build --no-default-features;
   fi
+# Check with all features
+- cargo check --features simd,atomics,sign_ext,bulk
 - cargo build --release --verbose
 - cargo test --release --verbose
 - cargo test --release --manifest-path=spec/Cargo.toml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,13 +25,17 @@ std = []
 #
 
 # Atomics aka threading.
-# https://github.com/webassembly/threads/blob/master/proposals/threads/Overview.md
+# https://github.com/webassembly/threads/
 atomics = []
 
 # SIMD
-# https://github.com/WebAssembly/simd/blob/master/proposals/simd/SIMD.md
+# https://github.com/WebAssembly/simd/
 simd = []
 
 # Sign-extension operators
-# https://github.com/WebAssembly/sign-extension-ops/blob/master/proposals/sign-extension-ops/Overview.md
+# https://github.com/WebAssembly/sign-extension-ops/
 sign_ext = []
+
+# Bulk-memory operators
+# https://github.com/WebAssembly/bulk-memory-operations/
+bulk = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ std = []
 
 #
 # Features for enabling non-MVP proposals.
+# These features should be tested as part of Travis CI build.
 #
 
 # Atomics aka threading.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,7 @@ atomics = []
 # SIMD
 # https://github.com/WebAssembly/simd/blob/master/proposals/simd/SIMD.md
 simd = []
+
+# Sign-extension operators
+# https://github.com/WebAssembly/sign-extension-ops/blob/master/proposals/sign-extension-ops/Overview.md
+sign_ext = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,7 @@ std = []
 # Atomics aka threading.
 # https://github.com/webassembly/threads/blob/master/proposals/threads/Overview.md
 atomics = []
+
+# SIMD
+# https://github.com/WebAssembly/simd/blob/master/proposals/simd/SIMD.md
+simd = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,11 @@ time = "0.1"
 [features]
 default = ["std"]
 std = []
+
+#
+# Features for enabling non-MVP proposals.
+#
+
+# Atomics aka threading.
+# https://github.com/webassembly/threads/blob/master/proposals/threads/Overview.md
+atomics = []

--- a/src/builder/data.rs
+++ b/src/builder/data.rs
@@ -50,7 +50,6 @@ impl<F> DataSegmentBuilder<F> where F: Invoke<elements::DataSegment> {
 				self.mem_index,
 				Some(self.offset),
 				self.value,
-				false,
 			)
 		)
 	}

--- a/src/builder/import.rs
+++ b/src/builder/import.rs
@@ -94,7 +94,7 @@ impl<F> ImportExternalBuilder<F> where F: Invoke<elements::External> {
 
 	/// Memory mapping with specified limits
 	pub fn memory(mut self, min: u32, max: Option<u32>) -> F::Result {
-		self.binding = elements::External::Memory(elements::MemoryType::new(min, max, false));
+		self.binding = elements::External::Memory(elements::MemoryType::new(min, max));
 		self.callback.invoke(self.binding)
 	}
 

--- a/src/builder/module.rs
+++ b/src/builder/module.rs
@@ -215,7 +215,7 @@ impl<F> ModuleBuilder<F> where F: Invoke<elements::Module> {
 		let memory_index = (entries.len() - 1) as u32;
 		for data in memory.data.drain(..) {
 			self.module.data.entries_mut()
-				.push(elements::DataSegment::new(memory_index, Some(data.offset), data.values, false))
+				.push(elements::DataSegment::new(memory_index, Some(data.offset), data.values))
 		}
 		memory_index
 	}
@@ -227,7 +227,7 @@ impl<F> ModuleBuilder<F> where F: Invoke<elements::Module> {
 		let table_index = (entries.len() - 1) as u32;
 		for entry in table.elements.drain(..) {
 			self.module.element.entries_mut()
-				.push(elements::ElementSegment::new(table_index, Some(entry.offset), entry.values, false))
+				.push(elements::ElementSegment::new(table_index, Some(entry.offset), entry.values))
 		}
 		table_index
 	}

--- a/src/builder/module.rs
+++ b/src/builder/module.rs
@@ -211,7 +211,7 @@ impl<F> ModuleBuilder<F> where F: Invoke<elements::Module> {
 	/// Push linear memory region
 	pub fn push_memory(&mut self, mut memory: memory::MemoryDefinition) -> u32 {
 		let entries = self.module.memory.entries_mut();
-		entries.push(elements::MemoryType::new(memory.min, memory.max, false));
+		entries.push(elements::MemoryType::new(memory.min, memory.max));
 		let memory_index = (entries.len() - 1) as u32;
 		for data in memory.data.drain(..) {
 			self.module.data.entries_mut()

--- a/src/elements/import_entry.rs
+++ b/src/elements/import_entry.rs
@@ -195,10 +195,7 @@ pub struct MemoryType(ResizableLimits);
 
 impl MemoryType {
 	/// New memory definition
-	pub fn new(
-		min: u32,
-		max: Option<u32>,
-	) -> Self {
+	pub fn new(min: u32, max: Option<u32>) -> Self {
 		let r = ResizableLimits::new(min, max);
 		MemoryType(r)
 	}

--- a/src/elements/mod.rs
+++ b/src/elements/mod.rs
@@ -48,7 +48,11 @@ pub use self::primitives::{
 	Uint64, VarUint64, CountedList, CountedWriter, CountedListWriter,
 };
 pub use self::types::{Type, ValueType, BlockType, FunctionType, TableElementType};
-pub use self::ops::{Instruction, Instructions, InitExpr, opcodes, MemArg, BrTableData};
+pub use self::ops::{Instruction, Instructions, InitExpr, opcodes, BrTableData};
+
+#[cfg(feature="atomics")]
+pub use self::ops::AtomicsInstruction;
+
 pub use self::func::{Func, FuncBody, Local};
 pub use self::segment::{ElementSegment, DataSegment};
 pub use self::index_map::IndexMap;

--- a/src/elements/mod.rs
+++ b/src/elements/mod.rs
@@ -53,6 +53,18 @@ pub use self::ops::{Instruction, Instructions, InitExpr, opcodes, BrTableData};
 #[cfg(feature="atomics")]
 pub use self::ops::AtomicsInstruction;
 
+#[cfg(feature="simd")]
+pub use self::ops::SimdInstruction;
+
+#[cfg(feature="sign_ext")]
+pub use self::ops::SignExtInstruction;
+
+#[cfg(feature="bulk")]
+pub use self::ops::BulkInstruction;
+
+#[cfg(any(feature="simd", feature="atomics"))]
+pub use self::ops::MemArg;
+
 pub use self::func::{Func, FuncBody, Local};
 pub use self::segment::{ElementSegment, DataSegment};
 pub use self::index_map::IndexMap;

--- a/src/elements/mod.rs
+++ b/src/elements/mod.rs
@@ -113,6 +113,7 @@ pub enum Error {
 	UnknownInternalKind(u8),
 	/// Unknown opcode encountered.
 	UnknownOpcode(u8),
+	#[cfg(feature="simd")]
 	/// Unknown SIMD opcode encountered.
 	UnknownSimdOpcode(u32),
 	/// Invalid VarUint1 value.
@@ -172,6 +173,7 @@ impl fmt::Display for Error {
 			Error::UnknownExternalKind(kind) => write!(f, "Unknown external kind {}", kind),
 			Error::UnknownInternalKind(kind) => write!(f, "Unknown internal kind {}", kind),
 			Error::UnknownOpcode(opcode) => write!(f, "Unknown opcode {}", opcode),
+			#[cfg(feature="simd")]
 			Error::UnknownSimdOpcode(opcode) => write!(f, "Unknown SIMD opcode {}", opcode),
 			Error::InvalidVarUint1(val) => write!(f, "Not an unsigned 1-bit integer: {}", val),
 			Error::InvalidVarInt7(val) => write!(f, "Not a signed 7-bit integer: {}", val),
@@ -212,6 +214,7 @@ impl ::std::error::Error for Error {
 			Error::UnknownExternalKind(_) => "Unknown external kind",
 			Error::UnknownInternalKind(_) => "Unknown internal kind",
 			Error::UnknownOpcode(_) => "Unknown opcode",
+			#[cfg(feature="simd")]
 			Error::UnknownSimdOpcode(_) => "Unknown SIMD opcode",
 			Error::InvalidVarUint1(_) => "Not an unsigned 1-bit integer",
 			Error::InvalidVarInt32 => "Not a signed 32-bit integer",

--- a/src/elements/module.rs
+++ b/src/elements/module.rs
@@ -785,10 +785,11 @@ mod integration_tests {
 		assert!(found_section, "Name section should be present in dedicated example");
 	}
 
+	// This test fixture has FLAG_SHARED so it depends on atomics feature.
 	#[test]
-	fn varuint1_case() {
-		let _module = deserialize_file("./res/cases/v1/varuint1_1.wasm")
-			.expect("Maybe shouldn't be deserialized");
+	fn shared_memory_flag() {
+		let module = deserialize_file("./res/cases/v1/varuint1_1.wasm");
+		assert_eq!(module.is_ok(), cfg!(feature="atomics"));
 	}
 
 

--- a/src/elements/ops.rs
+++ b/src/elements/ops.rs
@@ -568,6 +568,7 @@ pub enum BulkInstruction {
 	TableCopy,
 }
 
+#[cfg(any(feature="simd", feature="atomics"))]
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[allow(missing_docs)]
 pub struct MemArg {
@@ -1657,6 +1658,7 @@ fn deserialize_bulk<R: io::Read>(reader: &mut R) -> Result<Instruction, Error> {
 	}))
 }
 
+#[cfg(any(feature="simd", feature="atomics"))]
 impl Deserialize for MemArg {
 	type Error = Error;
 
@@ -2313,6 +2315,7 @@ impl Serialize for BulkInstruction {
 	}
 }
 
+#[cfg(any(feature="simd", feature="atomics"))]
 impl Serialize for MemArg {
 	type Error = Error;
 

--- a/src/elements/ops.rs
+++ b/src/elements/ops.rs
@@ -300,80 +300,8 @@ pub enum Instruction {
 	I64Extend16S,
 	I64Extend32S,
 
-	AtomicWake(MemArg),
-	I32AtomicWait(MemArg),
-	I64AtomicWait(MemArg),
-
-	I32AtomicLoad(MemArg),
-	I64AtomicLoad(MemArg),
-	I32AtomicLoad8u(MemArg),
-	I32AtomicLoad16u(MemArg),
-	I64AtomicLoad8u(MemArg),
-	I64AtomicLoad16u(MemArg),
-	I64AtomicLoad32u(MemArg),
-	I32AtomicStore(MemArg),
-	I64AtomicStore(MemArg),
-	I32AtomicStore8u(MemArg),
-	I32AtomicStore16u(MemArg),
-	I64AtomicStore8u(MemArg),
-	I64AtomicStore16u(MemArg),
-	I64AtomicStore32u(MemArg),
-
-	I32AtomicRmwAdd(MemArg),
-	I64AtomicRmwAdd(MemArg),
-	I32AtomicRmwAdd8u(MemArg),
-	I32AtomicRmwAdd16u(MemArg),
-	I64AtomicRmwAdd8u(MemArg),
-	I64AtomicRmwAdd16u(MemArg),
-	I64AtomicRmwAdd32u(MemArg),
-
-	I32AtomicRmwSub(MemArg),
-	I64AtomicRmwSub(MemArg),
-	I32AtomicRmwSub8u(MemArg),
-	I32AtomicRmwSub16u(MemArg),
-	I64AtomicRmwSub8u(MemArg),
-	I64AtomicRmwSub16u(MemArg),
-	I64AtomicRmwSub32u(MemArg),
-
-	I32AtomicRmwAnd(MemArg),
-	I64AtomicRmwAnd(MemArg),
-	I32AtomicRmwAnd8u(MemArg),
-	I32AtomicRmwAnd16u(MemArg),
-	I64AtomicRmwAnd8u(MemArg),
-	I64AtomicRmwAnd16u(MemArg),
-	I64AtomicRmwAnd32u(MemArg),
-
-	I32AtomicRmwOr(MemArg),
-	I64AtomicRmwOr(MemArg),
-	I32AtomicRmwOr8u(MemArg),
-	I32AtomicRmwOr16u(MemArg),
-	I64AtomicRmwOr8u(MemArg),
-	I64AtomicRmwOr16u(MemArg),
-	I64AtomicRmwOr32u(MemArg),
-
-	I32AtomicRmwXor(MemArg),
-	I64AtomicRmwXor(MemArg),
-	I32AtomicRmwXor8u(MemArg),
-	I32AtomicRmwXor16u(MemArg),
-	I64AtomicRmwXor8u(MemArg),
-	I64AtomicRmwXor16u(MemArg),
-	I64AtomicRmwXor32u(MemArg),
-
-	I32AtomicRmwXchg(MemArg),
-	I64AtomicRmwXchg(MemArg),
-	I32AtomicRmwXchg8u(MemArg),
-	I32AtomicRmwXchg16u(MemArg),
-	I64AtomicRmwXchg8u(MemArg),
-	I64AtomicRmwXchg16u(MemArg),
-	I64AtomicRmwXchg32u(MemArg),
-
-	I32AtomicRmwCmpxchg(MemArg),
-	I64AtomicRmwCmpxchg(MemArg),
-	I32AtomicRmwCmpxchg8u(MemArg),
-	I32AtomicRmwCmpxchg16u(MemArg),
-	I64AtomicRmwCmpxchg8u(MemArg),
-	I64AtomicRmwCmpxchg16u(MemArg),
-	I64AtomicRmwCmpxchg32u(MemArg),
+	#[cfg(feature="atomics")]
+	Atomics(AtomicsInstruction),
 
 	V128Const(Box<[u8; 16]>),
 	V128Load(MemArg),
@@ -535,6 +463,85 @@ pub enum Instruction {
 	TableInit(u32),
 	TableDrop(u32),
 	TableCopy,
+}
+
+#[cfg(feature="atomics")]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum AtomicsInstruction {
+	AtomicWake(MemArg),
+	I32AtomicWait(MemArg),
+	I64AtomicWait(MemArg),
+
+	I32AtomicLoad(MemArg),
+	I64AtomicLoad(MemArg),
+	I32AtomicLoad8u(MemArg),
+	I32AtomicLoad16u(MemArg),
+	I64AtomicLoad8u(MemArg),
+	I64AtomicLoad16u(MemArg),
+	I64AtomicLoad32u(MemArg),
+	I32AtomicStore(MemArg),
+	I64AtomicStore(MemArg),
+	I32AtomicStore8u(MemArg),
+	I32AtomicStore16u(MemArg),
+	I64AtomicStore8u(MemArg),
+	I64AtomicStore16u(MemArg),
+	I64AtomicStore32u(MemArg),
+
+	I32AtomicRmwAdd(MemArg),
+	I64AtomicRmwAdd(MemArg),
+	I32AtomicRmwAdd8u(MemArg),
+	I32AtomicRmwAdd16u(MemArg),
+	I64AtomicRmwAdd8u(MemArg),
+	I64AtomicRmwAdd16u(MemArg),
+	I64AtomicRmwAdd32u(MemArg),
+
+	I32AtomicRmwSub(MemArg),
+	I64AtomicRmwSub(MemArg),
+	I32AtomicRmwSub8u(MemArg),
+	I32AtomicRmwSub16u(MemArg),
+	I64AtomicRmwSub8u(MemArg),
+	I64AtomicRmwSub16u(MemArg),
+	I64AtomicRmwSub32u(MemArg),
+
+	I32AtomicRmwAnd(MemArg),
+	I64AtomicRmwAnd(MemArg),
+	I32AtomicRmwAnd8u(MemArg),
+	I32AtomicRmwAnd16u(MemArg),
+	I64AtomicRmwAnd8u(MemArg),
+	I64AtomicRmwAnd16u(MemArg),
+	I64AtomicRmwAnd32u(MemArg),
+
+	I32AtomicRmwOr(MemArg),
+	I64AtomicRmwOr(MemArg),
+	I32AtomicRmwOr8u(MemArg),
+	I32AtomicRmwOr16u(MemArg),
+	I64AtomicRmwOr8u(MemArg),
+	I64AtomicRmwOr16u(MemArg),
+	I64AtomicRmwOr32u(MemArg),
+
+	I32AtomicRmwXor(MemArg),
+	I64AtomicRmwXor(MemArg),
+	I32AtomicRmwXor8u(MemArg),
+	I32AtomicRmwXor16u(MemArg),
+	I64AtomicRmwXor8u(MemArg),
+	I64AtomicRmwXor16u(MemArg),
+	I64AtomicRmwXor32u(MemArg),
+
+	I32AtomicRmwXchg(MemArg),
+	I64AtomicRmwXchg(MemArg),
+	I32AtomicRmwXchg8u(MemArg),
+	I32AtomicRmwXchg16u(MemArg),
+	I64AtomicRmwXchg8u(MemArg),
+	I64AtomicRmwXchg16u(MemArg),
+	I64AtomicRmwXchg32u(MemArg),
+
+	I32AtomicRmwCmpxchg(MemArg),
+	I64AtomicRmwCmpxchg(MemArg),
+	I32AtomicRmwCmpxchg8u(MemArg),
+	I32AtomicRmwCmpxchg16u(MemArg),
+	I64AtomicRmwCmpxchg8u(MemArg),
+	I64AtomicRmwCmpxchg16u(MemArg),
+	I64AtomicRmwCmpxchg32u(MemArg),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -758,6 +765,7 @@ pub mod opcodes {
 	pub const I64_EXTEND16_S: u8 = 0xc3;
 	pub const I64_EXTEND32_S: u8 = 0xc4;
 
+	#[cfg(feature="atomics")]
 	pub const ATOMIC_PREFIX: u8 = 0xfe;
 	pub const ATOMIC_WAKE: u8 = 0x00;
 	pub const I32_ATOMIC_WAIT: u8 = 0x01;
@@ -1305,6 +1313,7 @@ impl Deserialize for Instruction {
 				I64_EXTEND16_S => I64Extend16S,
 				I64_EXTEND32_S => I64Extend32S,
 
+				#[cfg(feature="atomics")]
 				ATOMIC_PREFIX => return deserialize_atomic(reader),
 				SIMD_PREFIX => return deserialize_simd(reader),
 
@@ -1316,13 +1325,14 @@ impl Deserialize for Instruction {
 	}
 }
 
+#[cfg(feature="atomics")]
 fn deserialize_atomic<R: io::Read>(reader: &mut R) -> Result<Instruction, Error> {
-	use self::Instruction::*;
+	use self::AtomicsInstruction::*;
 	use self::opcodes::*;
 
 	let val: u8 = Uint8::deserialize(reader)?.into();
 	let mem = MemArg::deserialize(reader)?;
-	Ok(match val {
+	let atomics_instruction = match val {
 		ATOMIC_WAKE => AtomicWake(mem),
 		I32_ATOMIC_WAIT => I32AtomicWait(mem),
 		I64_ATOMIC_WAIT => I64AtomicWait(mem),
@@ -1391,7 +1401,9 @@ fn deserialize_atomic<R: io::Read>(reader: &mut R) -> Result<Instruction, Error>
 		I64_ATOMIC_RMW_CMPXCHG32U => I64AtomicRmwCmpxchg32u(mem),
 
 		_ => return Err(Error::UnknownOpcode(val)),
-	})
+	};
+
+	Ok(Instruction::Atomics(atomics_instruction))
 }
 
 fn deserialize_simd<R: io::Read>(reader: &mut R) -> Result<Instruction, Error> {
@@ -1630,6 +1642,7 @@ macro_rules! op {
 	});
 }
 
+#[cfg(feature="atomics")]
 macro_rules! atomic {
 	($writer: expr, $byte: expr, $mem:expr) => ({
 		$writer.write(&[ATOMIC_PREFIX, $byte])?;
@@ -1962,80 +1975,8 @@ impl Serialize for Instruction {
 			I64Extend16S => op!(writer, I64_EXTEND16_S),
 			I64Extend32S => op!(writer, I64_EXTEND32_S),
 
-			AtomicWake(m) => atomic!(writer, ATOMIC_WAKE, m),
-			I32AtomicWait(m) => atomic!(writer, I32_ATOMIC_WAIT, m),
-			I64AtomicWait(m) => atomic!(writer, I64_ATOMIC_WAIT, m),
-
-			I32AtomicLoad(m) => atomic!(writer, I32_ATOMIC_LOAD, m),
-			I64AtomicLoad(m) => atomic!(writer, I64_ATOMIC_LOAD, m),
-			I32AtomicLoad8u(m) => atomic!(writer, I32_ATOMIC_LOAD8U, m),
-			I32AtomicLoad16u(m) => atomic!(writer, I32_ATOMIC_LOAD16U, m),
-			I64AtomicLoad8u(m) => atomic!(writer, I64_ATOMIC_LOAD8U, m),
-			I64AtomicLoad16u(m) => atomic!(writer, I64_ATOMIC_LOAD16U, m),
-			I64AtomicLoad32u(m) => atomic!(writer, I64_ATOMIC_LOAD32U, m),
-			I32AtomicStore(m) => atomic!(writer, I32_ATOMIC_STORE, m),
-			I64AtomicStore(m) => atomic!(writer, I64_ATOMIC_STORE, m),
-			I32AtomicStore8u(m) => atomic!(writer, I32_ATOMIC_STORE8U, m),
-			I32AtomicStore16u(m) => atomic!(writer, I32_ATOMIC_STORE16U, m),
-			I64AtomicStore8u(m) => atomic!(writer, I64_ATOMIC_STORE8U, m),
-			I64AtomicStore16u(m) => atomic!(writer, I64_ATOMIC_STORE16U, m),
-			I64AtomicStore32u(m) => atomic!(writer, I64_ATOMIC_STORE32U, m),
-
-			I32AtomicRmwAdd(m) => atomic!(writer, I32_ATOMIC_RMW_ADD, m),
-			I64AtomicRmwAdd(m) => atomic!(writer, I64_ATOMIC_RMW_ADD, m),
-			I32AtomicRmwAdd8u(m) => atomic!(writer, I32_ATOMIC_RMW_ADD8U, m),
-			I32AtomicRmwAdd16u(m) => atomic!(writer, I32_ATOMIC_RMW_ADD16U, m),
-			I64AtomicRmwAdd8u(m) => atomic!(writer, I64_ATOMIC_RMW_ADD8U, m),
-			I64AtomicRmwAdd16u(m) => atomic!(writer, I64_ATOMIC_RMW_ADD16U, m),
-			I64AtomicRmwAdd32u(m) => atomic!(writer, I64_ATOMIC_RMW_ADD32U, m),
-
-			I32AtomicRmwSub(m) => atomic!(writer, I32_ATOMIC_RMW_SUB, m),
-			I64AtomicRmwSub(m) => atomic!(writer, I64_ATOMIC_RMW_SUB, m),
-			I32AtomicRmwSub8u(m) => atomic!(writer, I32_ATOMIC_RMW_SUB8U, m),
-			I32AtomicRmwSub16u(m) => atomic!(writer, I32_ATOMIC_RMW_SUB16U, m),
-			I64AtomicRmwSub8u(m) => atomic!(writer, I64_ATOMIC_RMW_SUB8U, m),
-			I64AtomicRmwSub16u(m) => atomic!(writer, I64_ATOMIC_RMW_SUB16U, m),
-			I64AtomicRmwSub32u(m) => atomic!(writer, I64_ATOMIC_RMW_SUB32U, m),
-
-			I32AtomicRmwAnd(m) => atomic!(writer, I32_ATOMIC_RMW_AND, m),
-			I64AtomicRmwAnd(m) => atomic!(writer, I64_ATOMIC_RMW_AND, m),
-			I32AtomicRmwAnd8u(m) => atomic!(writer, I32_ATOMIC_RMW_AND8U, m),
-			I32AtomicRmwAnd16u(m) => atomic!(writer, I32_ATOMIC_RMW_AND16U, m),
-			I64AtomicRmwAnd8u(m) => atomic!(writer, I64_ATOMIC_RMW_AND8U, m),
-			I64AtomicRmwAnd16u(m) => atomic!(writer, I64_ATOMIC_RMW_AND16U, m),
-			I64AtomicRmwAnd32u(m) => atomic!(writer, I64_ATOMIC_RMW_AND32U, m),
-
-			I32AtomicRmwOr(m) => atomic!(writer, I32_ATOMIC_RMW_OR, m),
-			I64AtomicRmwOr(m) => atomic!(writer, I64_ATOMIC_RMW_OR, m),
-			I32AtomicRmwOr8u(m) => atomic!(writer, I32_ATOMIC_RMW_OR8U, m),
-			I32AtomicRmwOr16u(m) => atomic!(writer, I32_ATOMIC_RMW_OR16U, m),
-			I64AtomicRmwOr8u(m) => atomic!(writer, I64_ATOMIC_RMW_OR8U, m),
-			I64AtomicRmwOr16u(m) => atomic!(writer, I64_ATOMIC_RMW_OR16U, m),
-			I64AtomicRmwOr32u(m) => atomic!(writer, I64_ATOMIC_RMW_OR32U, m),
-
-			I32AtomicRmwXor(m) => atomic!(writer, I32_ATOMIC_RMW_XOR, m),
-			I64AtomicRmwXor(m) => atomic!(writer, I64_ATOMIC_RMW_XOR, m),
-			I32AtomicRmwXor8u(m) => atomic!(writer, I32_ATOMIC_RMW_XOR8U, m),
-			I32AtomicRmwXor16u(m) => atomic!(writer, I32_ATOMIC_RMW_XOR16U, m),
-			I64AtomicRmwXor8u(m) => atomic!(writer, I64_ATOMIC_RMW_XOR8U, m),
-			I64AtomicRmwXor16u(m) => atomic!(writer, I64_ATOMIC_RMW_XOR16U, m),
-			I64AtomicRmwXor32u(m) => atomic!(writer, I64_ATOMIC_RMW_XOR32U, m),
-
-			I32AtomicRmwXchg(m) => atomic!(writer, I32_ATOMIC_RMW_XCHG, m),
-			I64AtomicRmwXchg(m) => atomic!(writer, I64_ATOMIC_RMW_XCHG, m),
-			I32AtomicRmwXchg8u(m) => atomic!(writer, I32_ATOMIC_RMW_XCHG8U, m),
-			I32AtomicRmwXchg16u(m) => atomic!(writer, I32_ATOMIC_RMW_XCHG16U, m),
-			I64AtomicRmwXchg8u(m) => atomic!(writer, I64_ATOMIC_RMW_XCHG8U, m),
-			I64AtomicRmwXchg16u(m) => atomic!(writer, I64_ATOMIC_RMW_XCHG16U, m),
-			I64AtomicRmwXchg32u(m) => atomic!(writer, I64_ATOMIC_RMW_XCHG32U, m),
-
-			I32AtomicRmwCmpxchg(m) => atomic!(writer, I32_ATOMIC_RMW_CMPXCHG, m),
-			I64AtomicRmwCmpxchg(m) => atomic!(writer, I64_ATOMIC_RMW_CMPXCHG, m),
-			I32AtomicRmwCmpxchg8u(m) => atomic!(writer, I32_ATOMIC_RMW_CMPXCHG8U, m),
-			I32AtomicRmwCmpxchg16u(m) => atomic!(writer, I32_ATOMIC_RMW_CMPXCHG16U, m),
-			I64AtomicRmwCmpxchg8u(m) => atomic!(writer, I64_ATOMIC_RMW_CMPXCHG8U, m),
-			I64AtomicRmwCmpxchg16u(m) => atomic!(writer, I64_ATOMIC_RMW_CMPXCHG16U, m),
-			I64AtomicRmwCmpxchg32u(m) => atomic!(writer, I64_ATOMIC_RMW_CMPXCHG32U, m),
+			#[cfg(feature="atomics")]
+			Atomics(a) => return a.serialize(writer),
 
 			V128Const(ref c) => simd!(writer, opcodes::V128_CONST, writer.write(&c[..])?),
 			V128Load(m) => simd!(writer, opcodes::V128_LOAD, MemArg::serialize(m, writer)?),
@@ -2208,6 +2149,95 @@ impl Serialize for Instruction {
 	}
 }
 
+#[cfg(feature="atomics")]
+impl Serialize for AtomicsInstruction {
+	type Error = Error;
+
+	fn serialize<W: io::Write>(self, writer: &mut W) -> Result<(), Self::Error> {
+		use self::AtomicsInstruction::*;
+		use self::opcodes::*;
+
+		match self {
+			AtomicWake(m) => atomic!(writer, ATOMIC_WAKE, m),
+			I32AtomicWait(m) => atomic!(writer, I32_ATOMIC_WAIT, m),
+			I64AtomicWait(m) => atomic!(writer, I64_ATOMIC_WAIT, m),
+
+			I32AtomicLoad(m) => atomic!(writer, I32_ATOMIC_LOAD, m),
+			I64AtomicLoad(m) => atomic!(writer, I64_ATOMIC_LOAD, m),
+			I32AtomicLoad8u(m) => atomic!(writer, I32_ATOMIC_LOAD8U, m),
+			I32AtomicLoad16u(m) => atomic!(writer, I32_ATOMIC_LOAD16U, m),
+			I64AtomicLoad8u(m) => atomic!(writer, I64_ATOMIC_LOAD8U, m),
+			I64AtomicLoad16u(m) => atomic!(writer, I64_ATOMIC_LOAD16U, m),
+			I64AtomicLoad32u(m) => atomic!(writer, I64_ATOMIC_LOAD32U, m),
+			I32AtomicStore(m) => atomic!(writer, I32_ATOMIC_STORE, m),
+			I64AtomicStore(m) => atomic!(writer, I64_ATOMIC_STORE, m),
+			I32AtomicStore8u(m) => atomic!(writer, I32_ATOMIC_STORE8U, m),
+			I32AtomicStore16u(m) => atomic!(writer, I32_ATOMIC_STORE16U, m),
+			I64AtomicStore8u(m) => atomic!(writer, I64_ATOMIC_STORE8U, m),
+			I64AtomicStore16u(m) => atomic!(writer, I64_ATOMIC_STORE16U, m),
+			I64AtomicStore32u(m) => atomic!(writer, I64_ATOMIC_STORE32U, m),
+
+			I32AtomicRmwAdd(m) => atomic!(writer, I32_ATOMIC_RMW_ADD, m),
+			I64AtomicRmwAdd(m) => atomic!(writer, I64_ATOMIC_RMW_ADD, m),
+			I32AtomicRmwAdd8u(m) => atomic!(writer, I32_ATOMIC_RMW_ADD8U, m),
+			I32AtomicRmwAdd16u(m) => atomic!(writer, I32_ATOMIC_RMW_ADD16U, m),
+			I64AtomicRmwAdd8u(m) => atomic!(writer, I64_ATOMIC_RMW_ADD8U, m),
+			I64AtomicRmwAdd16u(m) => atomic!(writer, I64_ATOMIC_RMW_ADD16U, m),
+			I64AtomicRmwAdd32u(m) => atomic!(writer, I64_ATOMIC_RMW_ADD32U, m),
+
+			I32AtomicRmwSub(m) => atomic!(writer, I32_ATOMIC_RMW_SUB, m),
+			I64AtomicRmwSub(m) => atomic!(writer, I64_ATOMIC_RMW_SUB, m),
+			I32AtomicRmwSub8u(m) => atomic!(writer, I32_ATOMIC_RMW_SUB8U, m),
+			I32AtomicRmwSub16u(m) => atomic!(writer, I32_ATOMIC_RMW_SUB16U, m),
+			I64AtomicRmwSub8u(m) => atomic!(writer, I64_ATOMIC_RMW_SUB8U, m),
+			I64AtomicRmwSub16u(m) => atomic!(writer, I64_ATOMIC_RMW_SUB16U, m),
+			I64AtomicRmwSub32u(m) => atomic!(writer, I64_ATOMIC_RMW_SUB32U, m),
+
+			I32AtomicRmwAnd(m) => atomic!(writer, I32_ATOMIC_RMW_AND, m),
+			I64AtomicRmwAnd(m) => atomic!(writer, I64_ATOMIC_RMW_AND, m),
+			I32AtomicRmwAnd8u(m) => atomic!(writer, I32_ATOMIC_RMW_AND8U, m),
+			I32AtomicRmwAnd16u(m) => atomic!(writer, I32_ATOMIC_RMW_AND16U, m),
+			I64AtomicRmwAnd8u(m) => atomic!(writer, I64_ATOMIC_RMW_AND8U, m),
+			I64AtomicRmwAnd16u(m) => atomic!(writer, I64_ATOMIC_RMW_AND16U, m),
+			I64AtomicRmwAnd32u(m) => atomic!(writer, I64_ATOMIC_RMW_AND32U, m),
+
+			I32AtomicRmwOr(m) => atomic!(writer, I32_ATOMIC_RMW_OR, m),
+			I64AtomicRmwOr(m) => atomic!(writer, I64_ATOMIC_RMW_OR, m),
+			I32AtomicRmwOr8u(m) => atomic!(writer, I32_ATOMIC_RMW_OR8U, m),
+			I32AtomicRmwOr16u(m) => atomic!(writer, I32_ATOMIC_RMW_OR16U, m),
+			I64AtomicRmwOr8u(m) => atomic!(writer, I64_ATOMIC_RMW_OR8U, m),
+			I64AtomicRmwOr16u(m) => atomic!(writer, I64_ATOMIC_RMW_OR16U, m),
+			I64AtomicRmwOr32u(m) => atomic!(writer, I64_ATOMIC_RMW_OR32U, m),
+
+			I32AtomicRmwXor(m) => atomic!(writer, I32_ATOMIC_RMW_XOR, m),
+			I64AtomicRmwXor(m) => atomic!(writer, I64_ATOMIC_RMW_XOR, m),
+			I32AtomicRmwXor8u(m) => atomic!(writer, I32_ATOMIC_RMW_XOR8U, m),
+			I32AtomicRmwXor16u(m) => atomic!(writer, I32_ATOMIC_RMW_XOR16U, m),
+			I64AtomicRmwXor8u(m) => atomic!(writer, I64_ATOMIC_RMW_XOR8U, m),
+			I64AtomicRmwXor16u(m) => atomic!(writer, I64_ATOMIC_RMW_XOR16U, m),
+			I64AtomicRmwXor32u(m) => atomic!(writer, I64_ATOMIC_RMW_XOR32U, m),
+
+			I32AtomicRmwXchg(m) => atomic!(writer, I32_ATOMIC_RMW_XCHG, m),
+			I64AtomicRmwXchg(m) => atomic!(writer, I64_ATOMIC_RMW_XCHG, m),
+			I32AtomicRmwXchg8u(m) => atomic!(writer, I32_ATOMIC_RMW_XCHG8U, m),
+			I32AtomicRmwXchg16u(m) => atomic!(writer, I32_ATOMIC_RMW_XCHG16U, m),
+			I64AtomicRmwXchg8u(m) => atomic!(writer, I64_ATOMIC_RMW_XCHG8U, m),
+			I64AtomicRmwXchg16u(m) => atomic!(writer, I64_ATOMIC_RMW_XCHG16U, m),
+			I64AtomicRmwXchg32u(m) => atomic!(writer, I64_ATOMIC_RMW_XCHG32U, m),
+
+			I32AtomicRmwCmpxchg(m) => atomic!(writer, I32_ATOMIC_RMW_CMPXCHG, m),
+			I64AtomicRmwCmpxchg(m) => atomic!(writer, I64_ATOMIC_RMW_CMPXCHG, m),
+			I32AtomicRmwCmpxchg8u(m) => atomic!(writer, I32_ATOMIC_RMW_CMPXCHG8U, m),
+			I32AtomicRmwCmpxchg16u(m) => atomic!(writer, I32_ATOMIC_RMW_CMPXCHG16U, m),
+			I64AtomicRmwCmpxchg8u(m) => atomic!(writer, I64_ATOMIC_RMW_CMPXCHG8U, m),
+			I64AtomicRmwCmpxchg16u(m) => atomic!(writer, I64_ATOMIC_RMW_CMPXCHG16U, m),
+			I64AtomicRmwCmpxchg32u(m) => atomic!(writer, I64_ATOMIC_RMW_CMPXCHG32U, m),
+		}
+
+		Ok(())
+	}
+}
+
 impl Serialize for MemArg {
 	type Error = Error;
 
@@ -2233,7 +2263,6 @@ macro_rules! fmt_op {
 impl fmt::Display for Instruction {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		use self::Instruction::*;
-		use super::BlockType;
 
 		match *self {
 			Unreachable => fmt_op!(f, "unreachable"),
@@ -2480,80 +2509,8 @@ impl fmt::Display for Instruction {
 			I64Extend16S => write!(f, "i64.extend16_s"),
 			I64Extend32S => write!(f, "i64.extend32_s"),
 
-			AtomicWake(_) => write!(f, "atomic.wake"),
-			I32AtomicWait(_) => write!(f, "i32.atomic.wait"),
-			I64AtomicWait(_) => write!(f, "i64.atomic.wait"),
-
-			I32AtomicLoad(_) => write!(f, "i32.atomic.load"),
-			I64AtomicLoad(_) => write!(f, "i64.atomic.load"),
-			I32AtomicLoad8u(_) => write!(f, "i32.atomic.load8_u"),
-			I32AtomicLoad16u(_) => write!(f, "i32.atomic.load16_u"),
-			I64AtomicLoad8u(_) => write!(f, "i64.atomic.load8_u"),
-			I64AtomicLoad16u(_) => write!(f, "i64.atomic.load16_u"),
-			I64AtomicLoad32u(_) => write!(f, "i64.atomic.load32_u"),
-			I32AtomicStore(_) => write!(f, "i32.atomic.store"),
-			I64AtomicStore(_) => write!(f, "i64.atomic.store"),
-			I32AtomicStore8u(_) => write!(f, "i32.atomic.store8_u"),
-			I32AtomicStore16u(_) => write!(f, "i32.atomic.store16_u"),
-			I64AtomicStore8u(_) => write!(f, "i64.atomic.store8_u"),
-			I64AtomicStore16u(_) => write!(f, "i64.atomic.store16_u"),
-			I64AtomicStore32u(_) => write!(f, "i64.atomic.store32_u"),
-
-			I32AtomicRmwAdd(_) => write!(f, "i32.atomic.rmw.add"),
-			I64AtomicRmwAdd(_) => write!(f, "i64.atomic.rmw.add"),
-			I32AtomicRmwAdd8u(_) => write!(f, "i32.atomic.rmw8_u.add"),
-			I32AtomicRmwAdd16u(_) => write!(f, "i32.atomic.rmw16_u.add"),
-			I64AtomicRmwAdd8u(_) => write!(f, "i64.atomic.rmw8_u.add"),
-			I64AtomicRmwAdd16u(_) => write!(f, "i64.atomic.rmw16_u.add"),
-			I64AtomicRmwAdd32u(_) => write!(f, "i64.atomic.rmw32_u.add"),
-
-			I32AtomicRmwSub(_) => write!(f, "i32.atomic.rmw.sub"),
-			I64AtomicRmwSub(_) => write!(f, "i64.atomic.rmw.sub"),
-			I32AtomicRmwSub8u(_) => write!(f, "i32.atomic.rmw8_u.sub"),
-			I32AtomicRmwSub16u(_) => write!(f, "i32.atomic.rmw16_u.sub"),
-			I64AtomicRmwSub8u(_) => write!(f, "i64.atomic.rmw8_u.sub"),
-			I64AtomicRmwSub16u(_) => write!(f, "i64.atomic.rmw16_u.sub"),
-			I64AtomicRmwSub32u(_) => write!(f, "i64.atomic.rmw32_u.sub"),
-
-			I32AtomicRmwAnd(_) => write!(f, "i32.atomic.rmw.and"),
-			I64AtomicRmwAnd(_) => write!(f, "i64.atomic.rmw.and"),
-			I32AtomicRmwAnd8u(_) => write!(f, "i32.atomic.rmw8_u.and"),
-			I32AtomicRmwAnd16u(_) => write!(f, "i32.atomic.rmw16_u.and"),
-			I64AtomicRmwAnd8u(_) => write!(f, "i64.atomic.rmw8_u.and"),
-			I64AtomicRmwAnd16u(_) => write!(f, "i64.atomic.rmw16_u.and"),
-			I64AtomicRmwAnd32u(_) => write!(f, "i64.atomic.rmw32_u.and"),
-
-			I32AtomicRmwOr(_) => write!(f, "i32.atomic.rmw.or"),
-			I64AtomicRmwOr(_) => write!(f, "i64.atomic.rmw.or"),
-			I32AtomicRmwOr8u(_) => write!(f, "i32.atomic.rmw8_u.or"),
-			I32AtomicRmwOr16u(_) => write!(f, "i32.atomic.rmw16_u.or"),
-			I64AtomicRmwOr8u(_) => write!(f, "i64.atomic.rmw8_u.or"),
-			I64AtomicRmwOr16u(_) => write!(f, "i64.atomic.rmw16_u.or"),
-			I64AtomicRmwOr32u(_) => write!(f, "i64.atomic.rmw32_u.or"),
-
-			I32AtomicRmwXor(_) => write!(f, "i32.atomic.rmw.xor"),
-			I64AtomicRmwXor(_) => write!(f, "i64.atomic.rmw.xor"),
-			I32AtomicRmwXor8u(_) => write!(f, "i32.atomic.rmw8_u.xor"),
-			I32AtomicRmwXor16u(_) => write!(f, "i32.atomic.rmw16_u.xor"),
-			I64AtomicRmwXor8u(_) => write!(f, "i64.atomic.rmw8_u.xor"),
-			I64AtomicRmwXor16u(_) => write!(f, "i64.atomic.rmw16_u.xor"),
-			I64AtomicRmwXor32u(_) => write!(f, "i64.atomic.rmw32_u.xor"),
-
-			I32AtomicRmwXchg(_) => write!(f, "i32.atomic.rmw.xchg"),
-			I64AtomicRmwXchg(_) => write!(f, "i64.atomic.rmw.xchg"),
-			I32AtomicRmwXchg8u(_) => write!(f, "i32.atomic.rmw8_u.xchg"),
-			I32AtomicRmwXchg16u(_) => write!(f, "i32.atomic.rmw16_u.xchg"),
-			I64AtomicRmwXchg8u(_) => write!(f, "i64.atomic.rmw8_u.xchg"),
-			I64AtomicRmwXchg16u(_) => write!(f, "i64.atomic.rmw16_u.xchg"),
-			I64AtomicRmwXchg32u(_) => write!(f, "i64.atomic.rmw32_u.xchg"),
-
-			I32AtomicRmwCmpxchg(_) => write!(f, "i32.atomic.rmw.cmpxchg"),
-			I64AtomicRmwCmpxchg(_) => write!(f, "i64.atomic.rmw.cmpxchg"),
-			I32AtomicRmwCmpxchg8u(_) => write!(f, "i32.atomic.rmw8_u.cmpxchg"),
-			I32AtomicRmwCmpxchg16u(_) => write!(f, "i32.atomic.rmw16_u.cmpxchg"),
-			I64AtomicRmwCmpxchg8u(_) => write!(f, "i64.atomic.rmw8_u.cmpxchg"),
-			I64AtomicRmwCmpxchg16u(_) => write!(f, "i64.atomic.rmw16_u.cmpxchg"),
-			I64AtomicRmwCmpxchg32u(_) => write!(f, "i64.atomic.rmw32_u.cmpxchg"),
+			#[cfg(feature="atomics")]
+			Atomics(ref i) => i.fmt(f),
 
 			V128Const(_) => write!(f, "v128.const"),
 			V128Load(_) => write!(f, "v128.load"),
@@ -2714,6 +2671,90 @@ impl fmt::Display for Instruction {
 			TableInit(_) => write!(f, "table.init"),
 			TableDrop(_) => write!(f, "table.drop"),
 			TableCopy => write!(f, "table.copy"),
+		}
+	}
+}
+
+#[cfg(feature="atomics")]
+impl fmt::Display for AtomicsInstruction {
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+		use self::AtomicsInstruction::*;
+
+		match *self {
+			AtomicWake(_) => write!(f, "atomic.wake"),
+			I32AtomicWait(_) => write!(f, "i32.atomic.wait"),
+			I64AtomicWait(_) => write!(f, "i64.atomic.wait"),
+
+			I32AtomicLoad(_) => write!(f, "i32.atomic.load"),
+			I64AtomicLoad(_) => write!(f, "i64.atomic.load"),
+			I32AtomicLoad8u(_) => write!(f, "i32.atomic.load8_u"),
+			I32AtomicLoad16u(_) => write!(f, "i32.atomic.load16_u"),
+			I64AtomicLoad8u(_) => write!(f, "i64.atomic.load8_u"),
+			I64AtomicLoad16u(_) => write!(f, "i64.atomic.load16_u"),
+			I64AtomicLoad32u(_) => write!(f, "i64.atomic.load32_u"),
+			I32AtomicStore(_) => write!(f, "i32.atomic.store"),
+			I64AtomicStore(_) => write!(f, "i64.atomic.store"),
+			I32AtomicStore8u(_) => write!(f, "i32.atomic.store8_u"),
+			I32AtomicStore16u(_) => write!(f, "i32.atomic.store16_u"),
+			I64AtomicStore8u(_) => write!(f, "i64.atomic.store8_u"),
+			I64AtomicStore16u(_) => write!(f, "i64.atomic.store16_u"),
+			I64AtomicStore32u(_) => write!(f, "i64.atomic.store32_u"),
+
+			I32AtomicRmwAdd(_) => write!(f, "i32.atomic.rmw.add"),
+			I64AtomicRmwAdd(_) => write!(f, "i64.atomic.rmw.add"),
+			I32AtomicRmwAdd8u(_) => write!(f, "i32.atomic.rmw8_u.add"),
+			I32AtomicRmwAdd16u(_) => write!(f, "i32.atomic.rmw16_u.add"),
+			I64AtomicRmwAdd8u(_) => write!(f, "i64.atomic.rmw8_u.add"),
+			I64AtomicRmwAdd16u(_) => write!(f, "i64.atomic.rmw16_u.add"),
+			I64AtomicRmwAdd32u(_) => write!(f, "i64.atomic.rmw32_u.add"),
+
+			I32AtomicRmwSub(_) => write!(f, "i32.atomic.rmw.sub"),
+			I64AtomicRmwSub(_) => write!(f, "i64.atomic.rmw.sub"),
+			I32AtomicRmwSub8u(_) => write!(f, "i32.atomic.rmw8_u.sub"),
+			I32AtomicRmwSub16u(_) => write!(f, "i32.atomic.rmw16_u.sub"),
+			I64AtomicRmwSub8u(_) => write!(f, "i64.atomic.rmw8_u.sub"),
+			I64AtomicRmwSub16u(_) => write!(f, "i64.atomic.rmw16_u.sub"),
+			I64AtomicRmwSub32u(_) => write!(f, "i64.atomic.rmw32_u.sub"),
+
+			I32AtomicRmwAnd(_) => write!(f, "i32.atomic.rmw.and"),
+			I64AtomicRmwAnd(_) => write!(f, "i64.atomic.rmw.and"),
+			I32AtomicRmwAnd8u(_) => write!(f, "i32.atomic.rmw8_u.and"),
+			I32AtomicRmwAnd16u(_) => write!(f, "i32.atomic.rmw16_u.and"),
+			I64AtomicRmwAnd8u(_) => write!(f, "i64.atomic.rmw8_u.and"),
+			I64AtomicRmwAnd16u(_) => write!(f, "i64.atomic.rmw16_u.and"),
+			I64AtomicRmwAnd32u(_) => write!(f, "i64.atomic.rmw32_u.and"),
+
+			I32AtomicRmwOr(_) => write!(f, "i32.atomic.rmw.or"),
+			I64AtomicRmwOr(_) => write!(f, "i64.atomic.rmw.or"),
+			I32AtomicRmwOr8u(_) => write!(f, "i32.atomic.rmw8_u.or"),
+			I32AtomicRmwOr16u(_) => write!(f, "i32.atomic.rmw16_u.or"),
+			I64AtomicRmwOr8u(_) => write!(f, "i64.atomic.rmw8_u.or"),
+			I64AtomicRmwOr16u(_) => write!(f, "i64.atomic.rmw16_u.or"),
+			I64AtomicRmwOr32u(_) => write!(f, "i64.atomic.rmw32_u.or"),
+
+			I32AtomicRmwXor(_) => write!(f, "i32.atomic.rmw.xor"),
+			I64AtomicRmwXor(_) => write!(f, "i64.atomic.rmw.xor"),
+			I32AtomicRmwXor8u(_) => write!(f, "i32.atomic.rmw8_u.xor"),
+			I32AtomicRmwXor16u(_) => write!(f, "i32.atomic.rmw16_u.xor"),
+			I64AtomicRmwXor8u(_) => write!(f, "i64.atomic.rmw8_u.xor"),
+			I64AtomicRmwXor16u(_) => write!(f, "i64.atomic.rmw16_u.xor"),
+			I64AtomicRmwXor32u(_) => write!(f, "i64.atomic.rmw32_u.xor"),
+
+			I32AtomicRmwXchg(_) => write!(f, "i32.atomic.rmw.xchg"),
+			I64AtomicRmwXchg(_) => write!(f, "i64.atomic.rmw.xchg"),
+			I32AtomicRmwXchg8u(_) => write!(f, "i32.atomic.rmw8_u.xchg"),
+			I32AtomicRmwXchg16u(_) => write!(f, "i32.atomic.rmw16_u.xchg"),
+			I64AtomicRmwXchg8u(_) => write!(f, "i64.atomic.rmw8_u.xchg"),
+			I64AtomicRmwXchg16u(_) => write!(f, "i64.atomic.rmw16_u.xchg"),
+			I64AtomicRmwXchg32u(_) => write!(f, "i64.atomic.rmw32_u.xchg"),
+
+			I32AtomicRmwCmpxchg(_) => write!(f, "i32.atomic.rmw.cmpxchg"),
+			I64AtomicRmwCmpxchg(_) => write!(f, "i64.atomic.rmw.cmpxchg"),
+			I32AtomicRmwCmpxchg8u(_) => write!(f, "i32.atomic.rmw8_u.cmpxchg"),
+			I32AtomicRmwCmpxchg16u(_) => write!(f, "i32.atomic.rmw16_u.cmpxchg"),
+			I64AtomicRmwCmpxchg8u(_) => write!(f, "i64.atomic.rmw8_u.cmpxchg"),
+			I64AtomicRmwCmpxchg16u(_) => write!(f, "i64.atomic.rmw16_u.cmpxchg"),
+			I64AtomicRmwCmpxchg32u(_) => write!(f, "i64.atomic.rmw32_u.cmpxchg"),
 		}
 	}
 }

--- a/src/elements/ops.rs
+++ b/src/elements/ops.rs
@@ -784,260 +784,271 @@ pub mod opcodes {
 	pub const F32REINTERPRETI32: u8 = 0xbe;
 	pub const F64REINTERPRETI64: u8 = 0xbf;
 
-	pub const I32_EXTEND8_S: u8 = 0xc0;
-	pub const I32_EXTEND16_S: u8 = 0xc1;
-	pub const I64_EXTEND8_S: u8 = 0xc2;
-	pub const I64_EXTEND16_S: u8 = 0xc3;
-	pub const I64_EXTEND32_S: u8 = 0xc4;
+	#[cfg(feature="sign_ext")]
+	pub mod sign_ext {
+		pub const I32_EXTEND8_S: u8 = 0xc0;
+		pub const I32_EXTEND16_S: u8 = 0xc1;
+		pub const I64_EXTEND8_S: u8 = 0xc2;
+		pub const I64_EXTEND16_S: u8 = 0xc3;
+		pub const I64_EXTEND32_S: u8 = 0xc4;
+	}
 
 	#[cfg(feature="atomics")]
-	pub const ATOMIC_PREFIX: u8 = 0xfe;
-	pub const ATOMIC_WAKE: u8 = 0x00;
-	pub const I32_ATOMIC_WAIT: u8 = 0x01;
-	pub const I64_ATOMIC_WAIT: u8 = 0x02;
+	pub mod atomics {
+		pub const ATOMIC_PREFIX: u8 = 0xfe;
+		pub const ATOMIC_WAKE: u8 = 0x00;
+		pub const I32_ATOMIC_WAIT: u8 = 0x01;
+		pub const I64_ATOMIC_WAIT: u8 = 0x02;
 
-	pub const I32_ATOMIC_LOAD: u8 = 0x10;
-	pub const I64_ATOMIC_LOAD: u8 = 0x11;
-	pub const I32_ATOMIC_LOAD8U: u8 = 0x12;
-	pub const I32_ATOMIC_LOAD16U: u8 = 0x13;
-	pub const I64_ATOMIC_LOAD8U: u8 = 0x14;
-	pub const I64_ATOMIC_LOAD16U: u8 = 0x15;
-	pub const I64_ATOMIC_LOAD32U: u8 = 0x16;
-	pub const I32_ATOMIC_STORE: u8 = 0x17;
-	pub const I64_ATOMIC_STORE: u8 = 0x18;
-	pub const I32_ATOMIC_STORE8U: u8 = 0x19;
-	pub const I32_ATOMIC_STORE16U: u8 = 0x1a;
-	pub const I64_ATOMIC_STORE8U: u8 = 0x1b;
-	pub const I64_ATOMIC_STORE16U: u8 = 0x1c;
-	pub const I64_ATOMIC_STORE32U: u8 = 0x1d;
+		pub const I32_ATOMIC_LOAD: u8 = 0x10;
+		pub const I64_ATOMIC_LOAD: u8 = 0x11;
+		pub const I32_ATOMIC_LOAD8U: u8 = 0x12;
+		pub const I32_ATOMIC_LOAD16U: u8 = 0x13;
+		pub const I64_ATOMIC_LOAD8U: u8 = 0x14;
+		pub const I64_ATOMIC_LOAD16U: u8 = 0x15;
+		pub const I64_ATOMIC_LOAD32U: u8 = 0x16;
+		pub const I32_ATOMIC_STORE: u8 = 0x17;
+		pub const I64_ATOMIC_STORE: u8 = 0x18;
+		pub const I32_ATOMIC_STORE8U: u8 = 0x19;
+		pub const I32_ATOMIC_STORE16U: u8 = 0x1a;
+		pub const I64_ATOMIC_STORE8U: u8 = 0x1b;
+		pub const I64_ATOMIC_STORE16U: u8 = 0x1c;
+		pub const I64_ATOMIC_STORE32U: u8 = 0x1d;
 
-	pub const I32_ATOMIC_RMW_ADD: u8 = 0x1e;
-	pub const I64_ATOMIC_RMW_ADD: u8 = 0x1f;
-	pub const I32_ATOMIC_RMW_ADD8U: u8 = 0x20;
-	pub const I32_ATOMIC_RMW_ADD16U: u8 = 0x21;
-	pub const I64_ATOMIC_RMW_ADD8U: u8 = 0x22;
-	pub const I64_ATOMIC_RMW_ADD16U: u8 = 0x23;
-	pub const I64_ATOMIC_RMW_ADD32U: u8 = 0x24;
+		pub const I32_ATOMIC_RMW_ADD: u8 = 0x1e;
+		pub const I64_ATOMIC_RMW_ADD: u8 = 0x1f;
+		pub const I32_ATOMIC_RMW_ADD8U: u8 = 0x20;
+		pub const I32_ATOMIC_RMW_ADD16U: u8 = 0x21;
+		pub const I64_ATOMIC_RMW_ADD8U: u8 = 0x22;
+		pub const I64_ATOMIC_RMW_ADD16U: u8 = 0x23;
+		pub const I64_ATOMIC_RMW_ADD32U: u8 = 0x24;
 
-	pub const I32_ATOMIC_RMW_SUB: u8 = 0x25;
-	pub const I64_ATOMIC_RMW_SUB: u8 = 0x26;
-	pub const I32_ATOMIC_RMW_SUB8U: u8 = 0x27;
-	pub const I32_ATOMIC_RMW_SUB16U: u8 = 0x28;
-	pub const I64_ATOMIC_RMW_SUB8U: u8 = 0x29;
-	pub const I64_ATOMIC_RMW_SUB16U: u8 = 0x2a;
-	pub const I64_ATOMIC_RMW_SUB32U: u8 = 0x2b;
+		pub const I32_ATOMIC_RMW_SUB: u8 = 0x25;
+		pub const I64_ATOMIC_RMW_SUB: u8 = 0x26;
+		pub const I32_ATOMIC_RMW_SUB8U: u8 = 0x27;
+		pub const I32_ATOMIC_RMW_SUB16U: u8 = 0x28;
+		pub const I64_ATOMIC_RMW_SUB8U: u8 = 0x29;
+		pub const I64_ATOMIC_RMW_SUB16U: u8 = 0x2a;
+		pub const I64_ATOMIC_RMW_SUB32U: u8 = 0x2b;
 
-	pub const I32_ATOMIC_RMW_AND: u8 = 0x2c;
-	pub const I64_ATOMIC_RMW_AND: u8 = 0x2d;
-	pub const I32_ATOMIC_RMW_AND8U: u8 = 0x2e;
-	pub const I32_ATOMIC_RMW_AND16U: u8 = 0x2f;
-	pub const I64_ATOMIC_RMW_AND8U: u8 = 0x30;
-	pub const I64_ATOMIC_RMW_AND16U: u8 = 0x31;
-	pub const I64_ATOMIC_RMW_AND32U: u8 = 0x32;
+		pub const I32_ATOMIC_RMW_AND: u8 = 0x2c;
+		pub const I64_ATOMIC_RMW_AND: u8 = 0x2d;
+		pub const I32_ATOMIC_RMW_AND8U: u8 = 0x2e;
+		pub const I32_ATOMIC_RMW_AND16U: u8 = 0x2f;
+		pub const I64_ATOMIC_RMW_AND8U: u8 = 0x30;
+		pub const I64_ATOMIC_RMW_AND16U: u8 = 0x31;
+		pub const I64_ATOMIC_RMW_AND32U: u8 = 0x32;
 
-	pub const I32_ATOMIC_RMW_OR: u8 = 0x33;
-	pub const I64_ATOMIC_RMW_OR: u8 = 0x34;
-	pub const I32_ATOMIC_RMW_OR8U: u8 = 0x35;
-	pub const I32_ATOMIC_RMW_OR16U: u8 = 0x36;
-	pub const I64_ATOMIC_RMW_OR8U: u8 = 0x37;
-	pub const I64_ATOMIC_RMW_OR16U: u8 = 0x38;
-	pub const I64_ATOMIC_RMW_OR32U: u8 = 0x39;
+		pub const I32_ATOMIC_RMW_OR: u8 = 0x33;
+		pub const I64_ATOMIC_RMW_OR: u8 = 0x34;
+		pub const I32_ATOMIC_RMW_OR8U: u8 = 0x35;
+		pub const I32_ATOMIC_RMW_OR16U: u8 = 0x36;
+		pub const I64_ATOMIC_RMW_OR8U: u8 = 0x37;
+		pub const I64_ATOMIC_RMW_OR16U: u8 = 0x38;
+		pub const I64_ATOMIC_RMW_OR32U: u8 = 0x39;
 
-	pub const I32_ATOMIC_RMW_XOR: u8 = 0x3a;
-	pub const I64_ATOMIC_RMW_XOR: u8 = 0x3b;
-	pub const I32_ATOMIC_RMW_XOR8U: u8 = 0x3c;
-	pub const I32_ATOMIC_RMW_XOR16U: u8 = 0x3d;
-	pub const I64_ATOMIC_RMW_XOR8U: u8 = 0x3e;
-	pub const I64_ATOMIC_RMW_XOR16U: u8 = 0x3f;
-	pub const I64_ATOMIC_RMW_XOR32U: u8 = 0x40;
+		pub const I32_ATOMIC_RMW_XOR: u8 = 0x3a;
+		pub const I64_ATOMIC_RMW_XOR: u8 = 0x3b;
+		pub const I32_ATOMIC_RMW_XOR8U: u8 = 0x3c;
+		pub const I32_ATOMIC_RMW_XOR16U: u8 = 0x3d;
+		pub const I64_ATOMIC_RMW_XOR8U: u8 = 0x3e;
+		pub const I64_ATOMIC_RMW_XOR16U: u8 = 0x3f;
+		pub const I64_ATOMIC_RMW_XOR32U: u8 = 0x40;
 
-	pub const I32_ATOMIC_RMW_XCHG: u8 = 0x41;
-	pub const I64_ATOMIC_RMW_XCHG: u8 = 0x42;
-	pub const I32_ATOMIC_RMW_XCHG8U: u8 = 0x43;
-	pub const I32_ATOMIC_RMW_XCHG16U: u8 = 0x44;
-	pub const I64_ATOMIC_RMW_XCHG8U: u8 = 0x45;
-	pub const I64_ATOMIC_RMW_XCHG16U: u8 = 0x46;
-	pub const I64_ATOMIC_RMW_XCHG32U: u8 = 0x47;
+		pub const I32_ATOMIC_RMW_XCHG: u8 = 0x41;
+		pub const I64_ATOMIC_RMW_XCHG: u8 = 0x42;
+		pub const I32_ATOMIC_RMW_XCHG8U: u8 = 0x43;
+		pub const I32_ATOMIC_RMW_XCHG16U: u8 = 0x44;
+		pub const I64_ATOMIC_RMW_XCHG8U: u8 = 0x45;
+		pub const I64_ATOMIC_RMW_XCHG16U: u8 = 0x46;
+		pub const I64_ATOMIC_RMW_XCHG32U: u8 = 0x47;
 
-	pub const I32_ATOMIC_RMW_CMPXCHG: u8 = 0x48;
-	pub const I64_ATOMIC_RMW_CMPXCHG: u8 = 0x49;
-	pub const I32_ATOMIC_RMW_CMPXCHG8U: u8 = 0x4a;
-	pub const I32_ATOMIC_RMW_CMPXCHG16U: u8 = 0x4b;
-	pub const I64_ATOMIC_RMW_CMPXCHG8U: u8 = 0x4c;
-	pub const I64_ATOMIC_RMW_CMPXCHG16U: u8 = 0x4d;
-	pub const I64_ATOMIC_RMW_CMPXCHG32U: u8 = 0x4e;
+		pub const I32_ATOMIC_RMW_CMPXCHG: u8 = 0x48;
+		pub const I64_ATOMIC_RMW_CMPXCHG: u8 = 0x49;
+		pub const I32_ATOMIC_RMW_CMPXCHG8U: u8 = 0x4a;
+		pub const I32_ATOMIC_RMW_CMPXCHG16U: u8 = 0x4b;
+		pub const I64_ATOMIC_RMW_CMPXCHG8U: u8 = 0x4c;
+		pub const I64_ATOMIC_RMW_CMPXCHG16U: u8 = 0x4d;
+		pub const I64_ATOMIC_RMW_CMPXCHG32U: u8 = 0x4e;
+	}
 
-	// https://github.com/WebAssembly/simd/blob/master/proposals/simd/BinarySIMD.md
-	pub const SIMD_PREFIX: u8 = 0xfd;
+	#[cfg(feature="simd")]
+	pub mod simd {
+		// https://github.com/WebAssembly/simd/blob/master/proposals/simd/BinarySIMD.md
+		pub const SIMD_PREFIX: u8 = 0xfd;
 
-	pub const V128_LOAD: u32 = 0x00;
-	pub const V128_STORE: u32 = 0x01;
-	pub const V128_CONST: u32 = 0x02;
-	pub const V8X16_SHUFFLE: u32 = 0x03;
+		pub const V128_LOAD: u32 = 0x00;
+		pub const V128_STORE: u32 = 0x01;
+		pub const V128_CONST: u32 = 0x02;
+		pub const V8X16_SHUFFLE: u32 = 0x03;
 
-	pub const I8X16_SPLAT: u32 = 0x04;
-	pub const I8X16_EXTRACT_LANE_S: u32 = 0x05;
-	pub const I8X16_EXTRACT_LANE_U: u32 = 0x06;
-	pub const I8X16_REPLACE_LANE: u32 = 0x07;
-	pub const I16X8_SPLAT: u32 = 0x08;
-	pub const I16X8_EXTRACT_LANE_S: u32 = 0x09;
-	pub const I16X8_EXTRACT_LANE_U: u32 = 0xa;
-	pub const I16X8_REPLACE_LANE: u32 = 0x0b;
-	pub const I32X4_SPLAT: u32 = 0x0c;
-	pub const I32X4_EXTRACT_LANE: u32 = 0x0d;
-	pub const I32X4_REPLACE_LANE: u32 = 0x0e;
-	pub const I64X2_SPLAT: u32 = 0x0f;
-	pub const I64X2_EXTRACT_LANE: u32 = 0x10;
-	pub const I64X2_REPLACE_LANE: u32 = 0x11;
-	pub const F32X4_SPLAT: u32 = 0x12;
-	pub const F32X4_EXTRACT_LANE: u32 = 0x13;
-	pub const F32X4_REPLACE_LANE: u32 = 0x14;
-	pub const F64X2_SPLAT: u32 = 0x15;
-	pub const F64X2_EXTRACT_LANE: u32 = 0x16;
-	pub const F64X2_REPLACE_LANE: u32 = 0x17;
+		pub const I8X16_SPLAT: u32 = 0x04;
+		pub const I8X16_EXTRACT_LANE_S: u32 = 0x05;
+		pub const I8X16_EXTRACT_LANE_U: u32 = 0x06;
+		pub const I8X16_REPLACE_LANE: u32 = 0x07;
+		pub const I16X8_SPLAT: u32 = 0x08;
+		pub const I16X8_EXTRACT_LANE_S: u32 = 0x09;
+		pub const I16X8_EXTRACT_LANE_U: u32 = 0xa;
+		pub const I16X8_REPLACE_LANE: u32 = 0x0b;
+		pub const I32X4_SPLAT: u32 = 0x0c;
+		pub const I32X4_EXTRACT_LANE: u32 = 0x0d;
+		pub const I32X4_REPLACE_LANE: u32 = 0x0e;
+		pub const I64X2_SPLAT: u32 = 0x0f;
+		pub const I64X2_EXTRACT_LANE: u32 = 0x10;
+		pub const I64X2_REPLACE_LANE: u32 = 0x11;
+		pub const F32X4_SPLAT: u32 = 0x12;
+		pub const F32X4_EXTRACT_LANE: u32 = 0x13;
+		pub const F32X4_REPLACE_LANE: u32 = 0x14;
+		pub const F64X2_SPLAT: u32 = 0x15;
+		pub const F64X2_EXTRACT_LANE: u32 = 0x16;
+		pub const F64X2_REPLACE_LANE: u32 = 0x17;
 
-	pub const I8X16_EQ: u32 = 0x18;
-	pub const I8X16_NE: u32 = 0x19;
-	pub const I8X16_LT_S: u32 = 0x1a;
-	pub const I8X16_LT_U: u32 = 0x1b;
-	pub const I8X16_GT_S: u32 = 0x1c;
-	pub const I8X16_GT_U: u32 = 0x1d;
-	pub const I8X16_LE_S: u32 = 0x1e;
-	pub const I8X16_LE_U: u32 = 0x1f;
-	pub const I8X16_GE_S: u32 = 0x20;
-	pub const I8X16_GE_U: u32 = 0x21;
+		pub const I8X16_EQ: u32 = 0x18;
+		pub const I8X16_NE: u32 = 0x19;
+		pub const I8X16_LT_S: u32 = 0x1a;
+		pub const I8X16_LT_U: u32 = 0x1b;
+		pub const I8X16_GT_S: u32 = 0x1c;
+		pub const I8X16_GT_U: u32 = 0x1d;
+		pub const I8X16_LE_S: u32 = 0x1e;
+		pub const I8X16_LE_U: u32 = 0x1f;
+		pub const I8X16_GE_S: u32 = 0x20;
+		pub const I8X16_GE_U: u32 = 0x21;
 
-	pub const I16X8_EQ: u32 = 0x22;
-	pub const I16X8_NE: u32 = 0x23;
-	pub const I16X8_LT_S: u32 = 0x24;
-	pub const I16X8_LT_U: u32 = 0x25;
-	pub const I16X8_GT_S: u32 = 0x26;
-	pub const I16X8_GT_U: u32 = 0x27;
-	pub const I16X8_LE_S: u32 = 0x28;
-	pub const I16X8_LE_U: u32 = 0x29;
-	pub const I16X8_GE_S: u32 = 0x2a;
-	pub const I16X8_GE_U: u32 = 0x2b;
+		pub const I16X8_EQ: u32 = 0x22;
+		pub const I16X8_NE: u32 = 0x23;
+		pub const I16X8_LT_S: u32 = 0x24;
+		pub const I16X8_LT_U: u32 = 0x25;
+		pub const I16X8_GT_S: u32 = 0x26;
+		pub const I16X8_GT_U: u32 = 0x27;
+		pub const I16X8_LE_S: u32 = 0x28;
+		pub const I16X8_LE_U: u32 = 0x29;
+		pub const I16X8_GE_S: u32 = 0x2a;
+		pub const I16X8_GE_U: u32 = 0x2b;
 
-	pub const I32X4_EQ: u32 = 0x2c;
-	pub const I32X4_NE: u32 = 0x2d;
-	pub const I32X4_LT_S: u32 = 0x2e;
-	pub const I32X4_LT_U: u32 = 0x2f;
-	pub const I32X4_GT_S: u32 = 0x30;
-	pub const I32X4_GT_U: u32 = 0x31;
-	pub const I32X4_LE_S: u32 = 0x32;
-	pub const I32X4_LE_U: u32 = 0x33;
-	pub const I32X4_GE_S: u32 = 0x34;
-	pub const I32X4_GE_U: u32 = 0x35;
+		pub const I32X4_EQ: u32 = 0x2c;
+		pub const I32X4_NE: u32 = 0x2d;
+		pub const I32X4_LT_S: u32 = 0x2e;
+		pub const I32X4_LT_U: u32 = 0x2f;
+		pub const I32X4_GT_S: u32 = 0x30;
+		pub const I32X4_GT_U: u32 = 0x31;
+		pub const I32X4_LE_S: u32 = 0x32;
+		pub const I32X4_LE_U: u32 = 0x33;
+		pub const I32X4_GE_S: u32 = 0x34;
+		pub const I32X4_GE_U: u32 = 0x35;
 
-	pub const F32X4_EQ: u32 = 0x40;
-	pub const F32X4_NE: u32 = 0x41;
-	pub const F32X4_LT: u32 = 0x42;
-	pub const F32X4_GT: u32 = 0x43;
-	pub const F32X4_LE: u32 = 0x44;
-	pub const F32X4_GE: u32 = 0x45;
+		pub const F32X4_EQ: u32 = 0x40;
+		pub const F32X4_NE: u32 = 0x41;
+		pub const F32X4_LT: u32 = 0x42;
+		pub const F32X4_GT: u32 = 0x43;
+		pub const F32X4_LE: u32 = 0x44;
+		pub const F32X4_GE: u32 = 0x45;
 
-	pub const F64X2_EQ: u32 = 0x46;
-	pub const F64X2_NE: u32 = 0x47;
-	pub const F64X2_LT: u32 = 0x48;
-	pub const F64X2_GT: u32 = 0x49;
-	pub const F64X2_LE: u32 = 0x4a;
-	pub const F64X2_GE: u32 = 0x4b;
+		pub const F64X2_EQ: u32 = 0x46;
+		pub const F64X2_NE: u32 = 0x47;
+		pub const F64X2_LT: u32 = 0x48;
+		pub const F64X2_GT: u32 = 0x49;
+		pub const F64X2_LE: u32 = 0x4a;
+		pub const F64X2_GE: u32 = 0x4b;
 
-	pub const V128_NOT: u32 = 0x4c;
-	pub const V128_AND: u32 = 0x4d;
-	pub const V128_OR: u32 = 0x4e;
-	pub const V128_XOR: u32 = 0x4f;
-	pub const V128_BITSELECT: u32 = 0x50;
+		pub const V128_NOT: u32 = 0x4c;
+		pub const V128_AND: u32 = 0x4d;
+		pub const V128_OR: u32 = 0x4e;
+		pub const V128_XOR: u32 = 0x4f;
+		pub const V128_BITSELECT: u32 = 0x50;
 
-	pub const I8X16_NEG: u32 = 0x51;
-	pub const I8X16_ANY_TRUE: u32 = 0x52;
-	pub const I8X16_ALL_TRUE: u32 = 0x53;
-	pub const I8X16_SHL: u32 = 0x54;
-	pub const I8X16_SHR_S: u32 = 0x55;
-	pub const I8X16_SHR_U: u32 = 0x56;
-	pub const I8X16_ADD: u32 = 0x57;
-	pub const I8X16_ADD_SATURATE_S: u32 = 0x58;
-	pub const I8X16_ADD_SATURATE_U: u32 = 0x59;
-	pub const I8X16_SUB: u32 = 0x5a;
-	pub const I8X16_SUB_SATURATE_S: u32 = 0x5b;
-	pub const I8X16_SUB_SATURATE_U: u32 = 0x5c;
-	pub const I8X16_MUL: u32 = 0x5d;
+		pub const I8X16_NEG: u32 = 0x51;
+		pub const I8X16_ANY_TRUE: u32 = 0x52;
+		pub const I8X16_ALL_TRUE: u32 = 0x53;
+		pub const I8X16_SHL: u32 = 0x54;
+		pub const I8X16_SHR_S: u32 = 0x55;
+		pub const I8X16_SHR_U: u32 = 0x56;
+		pub const I8X16_ADD: u32 = 0x57;
+		pub const I8X16_ADD_SATURATE_S: u32 = 0x58;
+		pub const I8X16_ADD_SATURATE_U: u32 = 0x59;
+		pub const I8X16_SUB: u32 = 0x5a;
+		pub const I8X16_SUB_SATURATE_S: u32 = 0x5b;
+		pub const I8X16_SUB_SATURATE_U: u32 = 0x5c;
+		pub const I8X16_MUL: u32 = 0x5d;
 
-	pub const I16X8_NEG: u32 = 0x62;
-	pub const I16X8_ANY_TRUE: u32 = 0x63;
-	pub const I16X8_ALL_TRUE: u32 = 0x64;
-	pub const I16X8_SHL: u32 = 0x65;
-	pub const I16X8_SHR_S: u32 = 0x66;
-	pub const I16X8_SHR_U: u32 = 0x67;
-	pub const I16X8_ADD: u32 = 0x68;
-	pub const I16X8_ADD_SATURATE_S: u32 = 0x69;
-	pub const I16X8_ADD_SATURATE_U: u32 = 0x6a;
-	pub const I16X8_SUB: u32 = 0x6b;
-	pub const I16X8_SUB_SATURATE_S: u32 = 0x6c;
-	pub const I16X8_SUB_SATURATE_U: u32 = 0x6d;
-	pub const I16X8_MUL: u32 = 0x6e;
+		pub const I16X8_NEG: u32 = 0x62;
+		pub const I16X8_ANY_TRUE: u32 = 0x63;
+		pub const I16X8_ALL_TRUE: u32 = 0x64;
+		pub const I16X8_SHL: u32 = 0x65;
+		pub const I16X8_SHR_S: u32 = 0x66;
+		pub const I16X8_SHR_U: u32 = 0x67;
+		pub const I16X8_ADD: u32 = 0x68;
+		pub const I16X8_ADD_SATURATE_S: u32 = 0x69;
+		pub const I16X8_ADD_SATURATE_U: u32 = 0x6a;
+		pub const I16X8_SUB: u32 = 0x6b;
+		pub const I16X8_SUB_SATURATE_S: u32 = 0x6c;
+		pub const I16X8_SUB_SATURATE_U: u32 = 0x6d;
+		pub const I16X8_MUL: u32 = 0x6e;
 
-	pub const I32X4_NEG: u32 = 0x73;
-	pub const I32X4_ANY_TRUE: u32 = 0x74;
-	pub const I32X4_ALL_TRUE: u32 = 0x75;
-	pub const I32X4_SHL: u32 = 0x76;
-	pub const I32X4_SHR_S: u32 = 0x77;
-	pub const I32X4_SHR_U: u32 = 0x78;
-	pub const I32X4_ADD: u32 = 0x79;
-	pub const I32X4_ADD_SATURATE_S: u32 = 0x7a;
-	pub const I32X4_ADD_SATURATE_U: u32 = 0x7b;
-	pub const I32X4_SUB: u32 = 0x7c;
-	pub const I32X4_SUB_SATURATE_S: u32 = 0x7d;
-	pub const I32X4_SUB_SATURATE_U: u32 = 0x7e;
-	pub const I32X4_MUL: u32 = 0x7f;
+		pub const I32X4_NEG: u32 = 0x73;
+		pub const I32X4_ANY_TRUE: u32 = 0x74;
+		pub const I32X4_ALL_TRUE: u32 = 0x75;
+		pub const I32X4_SHL: u32 = 0x76;
+		pub const I32X4_SHR_S: u32 = 0x77;
+		pub const I32X4_SHR_U: u32 = 0x78;
+		pub const I32X4_ADD: u32 = 0x79;
+		pub const I32X4_ADD_SATURATE_S: u32 = 0x7a;
+		pub const I32X4_ADD_SATURATE_U: u32 = 0x7b;
+		pub const I32X4_SUB: u32 = 0x7c;
+		pub const I32X4_SUB_SATURATE_S: u32 = 0x7d;
+		pub const I32X4_SUB_SATURATE_U: u32 = 0x7e;
+		pub const I32X4_MUL: u32 = 0x7f;
 
-	pub const I64X2_NEG: u32 = 0x84;
-	pub const I64X2_ANY_TRUE: u32 = 0x85;
-	pub const I64X2_ALL_TRUE: u32 = 0x86;
-	pub const I64X2_SHL: u32 = 0x87;
-	pub const I64X2_SHR_S: u32 = 0x88;
-	pub const I64X2_SHR_U: u32 = 0x89;
-	pub const I64X2_ADD: u32 = 0x8a;
-	pub const I64X2_SUB: u32 = 0x8d;
+		pub const I64X2_NEG: u32 = 0x84;
+		pub const I64X2_ANY_TRUE: u32 = 0x85;
+		pub const I64X2_ALL_TRUE: u32 = 0x86;
+		pub const I64X2_SHL: u32 = 0x87;
+		pub const I64X2_SHR_S: u32 = 0x88;
+		pub const I64X2_SHR_U: u32 = 0x89;
+		pub const I64X2_ADD: u32 = 0x8a;
+		pub const I64X2_SUB: u32 = 0x8d;
 
-	pub const F32X4_ABS: u32 = 0x95;
-	pub const F32X4_NEG: u32 = 0x96;
-	pub const F32X4_SQRT: u32 = 0x97;
-	pub const F32X4_ADD: u32 = 0x9a;
-	pub const F32X4_SUB: u32 = 0x9b;
-	pub const F32X4_MUL: u32 = 0x9c;
-	pub const F32X4_DIV: u32 = 0x9d;
-	pub const F32X4_MIN: u32 = 0x9e;
-	pub const F32X4_MAX: u32 = 0x9f;
+		pub const F32X4_ABS: u32 = 0x95;
+		pub const F32X4_NEG: u32 = 0x96;
+		pub const F32X4_SQRT: u32 = 0x97;
+		pub const F32X4_ADD: u32 = 0x9a;
+		pub const F32X4_SUB: u32 = 0x9b;
+		pub const F32X4_MUL: u32 = 0x9c;
+		pub const F32X4_DIV: u32 = 0x9d;
+		pub const F32X4_MIN: u32 = 0x9e;
+		pub const F32X4_MAX: u32 = 0x9f;
 
-	pub const F64X2_ABS: u32 = 0xa0;
-	pub const F64X2_NEG: u32 = 0xa1;
-	pub const F64X2_SQRT: u32 = 0xa2;
-	pub const F64X2_ADD: u32 = 0xa5;
-	pub const F64X2_SUB: u32 = 0xa6;
-	pub const F64X2_MUL: u32 = 0xa7;
-	pub const F64X2_DIV: u32 = 0xa8;
-	pub const F64X2_MIN: u32 = 0xa9;
-	pub const F64X2_MAX: u32 = 0xaa;
+		pub const F64X2_ABS: u32 = 0xa0;
+		pub const F64X2_NEG: u32 = 0xa1;
+		pub const F64X2_SQRT: u32 = 0xa2;
+		pub const F64X2_ADD: u32 = 0xa5;
+		pub const F64X2_SUB: u32 = 0xa6;
+		pub const F64X2_MUL: u32 = 0xa7;
+		pub const F64X2_DIV: u32 = 0xa8;
+		pub const F64X2_MIN: u32 = 0xa9;
+		pub const F64X2_MAX: u32 = 0xaa;
 
-	pub const I32X4_TRUNC_S_F32X4_SAT: u32 = 0xab;
-	pub const I32X4_TRUNC_U_F32X4_SAT: u32 = 0xac;
-	pub const I64X2_TRUNC_S_F64X2_SAT: u32 = 0xad;
-	pub const I64X2_TRUNC_U_F64X2_SAT: u32 = 0xae;
+		pub const I32X4_TRUNC_S_F32X4_SAT: u32 = 0xab;
+		pub const I32X4_TRUNC_U_F32X4_SAT: u32 = 0xac;
+		pub const I64X2_TRUNC_S_F64X2_SAT: u32 = 0xad;
+		pub const I64X2_TRUNC_U_F64X2_SAT: u32 = 0xae;
 
-	pub const F32X4_CONVERT_S_I32X4: u32 = 0xaf;
-	pub const F32X4_CONVERT_U_I32X4: u32 = 0xb0;
-	pub const F64X2_CONVERT_S_I64X2: u32 = 0xb1;
-	pub const F64X2_CONVERT_U_I64X2: u32 = 0xb2;
+		pub const F32X4_CONVERT_S_I32X4: u32 = 0xaf;
+		pub const F32X4_CONVERT_U_I32X4: u32 = 0xb0;
+		pub const F64X2_CONVERT_S_I64X2: u32 = 0xb1;
+		pub const F64X2_CONVERT_U_I64X2: u32 = 0xb2;
+	}
 
-	pub const BULK_PREFIX: u8 = 0xfc;
-	pub const MEMORY_INIT: u8 = 0x08;
-	pub const MEMORY_DROP: u8 = 0x09;
-	pub const MEMORY_COPY: u8 = 0x0a;
-	pub const MEMORY_FILL: u8 = 0x0b;
-	pub const TABLE_INIT: u8 = 0x0c;
-	pub const TABLE_DROP: u8 = 0x0d;
-	pub const TABLE_COPY: u8 = 0x0e;
+	#[cfg(feature="bulk")]
+	pub mod bulk {
+		pub const BULK_PREFIX: u8 = 0xfc;
+		pub const MEMORY_INIT: u8 = 0x08;
+		pub const MEMORY_DROP: u8 = 0x09;
+		pub const MEMORY_COPY: u8 = 0x0a;
+		pub const MEMORY_FILL: u8 = 0x0b;
+		pub const TABLE_INIT: u8 = 0x0c;
+		pub const TABLE_DROP: u8 = 0x0d;
+		pub const TABLE_COPY: u8 = 0x0e;
+	}
 }
 
 impl Deserialize for Instruction {
@@ -1046,6 +1057,9 @@ impl Deserialize for Instruction {
 	fn deserialize<R: io::Read>(reader: &mut R) -> Result<Self, Self::Error> {
 		use self::Instruction::*;
 		use self::opcodes::*;
+
+		#[cfg(feature="sign_ext")]
+		use self::opcodes::sign_ext::*;
 
 		let val: u8 = Uint8::deserialize(reader)?.into();
 
@@ -1348,13 +1362,13 @@ impl Deserialize for Instruction {
 				}
 
 				#[cfg(feature="atomics")]
-				ATOMIC_PREFIX => return deserialize_atomic(reader),
+				atomics::ATOMIC_PREFIX => return deserialize_atomic(reader),
 
 				#[cfg(feature="simd")]
-				SIMD_PREFIX => return deserialize_simd(reader),
+				simd::SIMD_PREFIX => return deserialize_simd(reader),
 
 				#[cfg(feature="bulk")]
-				BULK_PREFIX => return deserialize_bulk(reader),
+				bulk::BULK_PREFIX => return deserialize_bulk(reader),
 
 				_ => { return Err(Error::UnknownOpcode(val)); }
 			}
@@ -1365,7 +1379,7 @@ impl Deserialize for Instruction {
 #[cfg(feature="atomics")]
 fn deserialize_atomic<R: io::Read>(reader: &mut R) -> Result<Instruction, Error> {
 	use self::AtomicsInstruction::*;
-	use self::opcodes::*;
+	use self::opcodes::atomics::*;
 
 	let val: u8 = Uint8::deserialize(reader)?.into();
 	let mem = MemArg::deserialize(reader)?;
@@ -1444,7 +1458,7 @@ fn deserialize_atomic<R: io::Read>(reader: &mut R) -> Result<Instruction, Error>
 #[cfg(feature="simd")]
 fn deserialize_simd<R: io::Read>(reader: &mut R) -> Result<Instruction, Error> {
 	use self::SimdInstruction::*;
-	use self::opcodes::*;
+	use self::opcodes::simd::*;
 
 	let val = VarUint32::deserialize(reader)?.into();
 	Ok(Instruction::Simd(match val {
@@ -1616,7 +1630,7 @@ fn deserialize_simd<R: io::Read>(reader: &mut R) -> Result<Instruction, Error> {
 #[cfg(feature="bulk")]
 fn deserialize_bulk<R: io::Read>(reader: &mut R) -> Result<Instruction, Error> {
 	use self::BulkInstruction::*;
-	use self::opcodes::*;
+	use self::opcodes::bulk::*;
 
 	let val: u8 = Uint8::deserialize(reader)?.into();
 	Ok(Instruction::Bulk(match val {
@@ -2011,11 +2025,11 @@ impl Serialize for Instruction {
 
 			#[cfg(feature="sign_ext")]
 			SignExt(ref a) => match *a {
-				SignExtInstruction::I32Extend8S => op!(writer, I32_EXTEND8_S),
-				SignExtInstruction::I32Extend16S => op!(writer, I32_EXTEND16_S),
-				SignExtInstruction::I64Extend8S => op!(writer, I64_EXTEND8_S),
-				SignExtInstruction::I64Extend16S => op!(writer, I64_EXTEND16_S),
-				SignExtInstruction::I64Extend32S => op!(writer, I64_EXTEND32_S),
+				SignExtInstruction::I32Extend8S => op!(writer, sign_ext::I32_EXTEND8_S),
+				SignExtInstruction::I32Extend16S => op!(writer, sign_ext::I32_EXTEND16_S),
+				SignExtInstruction::I64Extend8S => op!(writer, sign_ext::I64_EXTEND8_S),
+				SignExtInstruction::I64Extend16S => op!(writer, sign_ext::I64_EXTEND16_S),
+				SignExtInstruction::I64Extend32S => op!(writer, sign_ext::I64_EXTEND32_S),
 			}
 
 			#[cfg(feature="atomics")]
@@ -2038,7 +2052,7 @@ impl Serialize for AtomicsInstruction {
 
 	fn serialize<W: io::Write>(self, writer: &mut W) -> Result<(), Self::Error> {
 		use self::AtomicsInstruction::*;
-		use self::opcodes::*;
+		use self::opcodes::atomics::*;
 
 		match self {
 			AtomicWake(m) => atomic!(writer, ATOMIC_WAKE, m),
@@ -2127,160 +2141,160 @@ impl Serialize for SimdInstruction {
 
 	fn serialize<W: io::Write>(self, writer: &mut W) -> Result<(), Self::Error> {
 		use self::SimdInstruction::*;
-		use self::opcodes::*;
+		use self::opcodes::simd::*;
 
 		match self {
-			V128Const(ref c) => simd!(writer, opcodes::V128_CONST, writer.write(&c[..])?),
-			V128Load(m) => simd!(writer, opcodes::V128_LOAD, MemArg::serialize(m, writer)?),
-			V128Store(m) => simd!(writer, opcodes::V128_STORE, MemArg::serialize(m, writer)?),
-			I8x16Splat => simd!(writer, opcodes::I8X16_SPLAT, ()),
-			I16x8Splat => simd!(writer, opcodes::I16X8_SPLAT, ()),
-			I32x4Splat => simd!(writer, opcodes::I32X4_SPLAT, ()),
-			I64x2Splat => simd!(writer, opcodes::I64X2_SPLAT, ()),
-			F32x4Splat => simd!(writer, opcodes::F32X4_SPLAT, ()),
-			F64x2Splat => simd!(writer, opcodes::F64X2_SPLAT, ()),
-			I8x16ExtractLaneS(i) => simd!(writer, opcodes::I8X16_EXTRACT_LANE_S, writer.write(&[i])?),
-			I8x16ExtractLaneU(i) => simd!(writer, opcodes::I8X16_EXTRACT_LANE_U, writer.write(&[i])?),
-			I16x8ExtractLaneS(i) => simd!(writer, opcodes::I16X8_EXTRACT_LANE_S, writer.write(&[i])?),
-			I16x8ExtractLaneU(i) => simd!(writer, opcodes::I16X8_EXTRACT_LANE_U, writer.write(&[i])?),
-			I32x4ExtractLane(i) => simd!(writer, opcodes::I32X4_EXTRACT_LANE, writer.write(&[i])?),
-			I64x2ExtractLane(i) => simd!(writer, opcodes::I64X2_EXTRACT_LANE, writer.write(&[i])?),
-			F32x4ExtractLane(i) => simd!(writer, opcodes::F32X4_EXTRACT_LANE, writer.write(&[i])?),
-			F64x2ExtractLane(i) => simd!(writer, opcodes::F64X2_EXTRACT_LANE, writer.write(&[i])?),
-			I8x16ReplaceLane(i) => simd!(writer, opcodes::I8X16_REPLACE_LANE, writer.write(&[i])?),
-			I16x8ReplaceLane(i) => simd!(writer, opcodes::I16X8_REPLACE_LANE, writer.write(&[i])?),
-			I32x4ReplaceLane(i) => simd!(writer, opcodes::I32X4_REPLACE_LANE, writer.write(&[i])?),
-			I64x2ReplaceLane(i) => simd!(writer, opcodes::I64X2_REPLACE_LANE, writer.write(&[i])?),
-			F32x4ReplaceLane(i) => simd!(writer, opcodes::F32X4_REPLACE_LANE, writer.write(&[i])?),
-			F64x2ReplaceLane(i) => simd!(writer, opcodes::F64X2_REPLACE_LANE, writer.write(&[i])?),
-			V8x16Shuffle(ref i) => simd!(writer, opcodes::V8X16_SHUFFLE, writer.write(&i[..])?),
-			I8x16Add => simd!(writer, opcodes::I8X16_ADD, ()),
-			I16x8Add => simd!(writer, opcodes::I16X8_ADD, ()),
-			I32x4Add => simd!(writer, opcodes::I32X4_ADD, ()),
-			I64x2Add => simd!(writer, opcodes::I64X2_ADD, ()),
-			I8x16Sub => simd!(writer, opcodes::I8X16_SUB, ()),
-			I16x8Sub => simd!(writer, opcodes::I16X8_SUB, ()),
-			I32x4Sub => simd!(writer, opcodes::I32X4_SUB, ()),
-			I64x2Sub => simd!(writer, opcodes::I64X2_SUB, ()),
-			I8x16Mul => simd!(writer, opcodes::I8X16_MUL, ()),
-			I16x8Mul => simd!(writer, opcodes::I16X8_MUL, ()),
-			I32x4Mul => simd!(writer, opcodes::I32X4_MUL, ()),
-			// I64x2Mul => simd!(writer, opcodes::I64X2_MUL, ()),
-			I8x16Neg => simd!(writer, opcodes::I8X16_NEG, ()),
-			I16x8Neg => simd!(writer, opcodes::I16X8_NEG, ()),
-			I32x4Neg => simd!(writer, opcodes::I32X4_NEG, ()),
-			I64x2Neg => simd!(writer, opcodes::I64X2_NEG, ()),
-			I8x16AddSaturateS => simd!(writer, opcodes::I8X16_ADD_SATURATE_S, ()),
-			I8x16AddSaturateU => simd!(writer, opcodes::I8X16_ADD_SATURATE_U, ()),
-			I16x8AddSaturateS => simd!(writer, opcodes::I16X8_ADD_SATURATE_S, ()),
-			I16x8AddSaturateU => simd!(writer, opcodes::I16X8_ADD_SATURATE_U, ()),
-			I8x16SubSaturateS => simd!(writer, opcodes::I8X16_SUB_SATURATE_S, ()),
-			I8x16SubSaturateU => simd!(writer, opcodes::I8X16_SUB_SATURATE_U, ()),
-			I16x8SubSaturateS => simd!(writer, opcodes::I16X8_SUB_SATURATE_S, ()),
-			I16x8SubSaturateU => simd!(writer, opcodes::I16X8_SUB_SATURATE_U, ()),
-			I8x16Shl => simd!(writer, opcodes::I8X16_SHL, ()),
-			I16x8Shl => simd!(writer, opcodes::I16X8_SHL, ()),
-			I32x4Shl => simd!(writer, opcodes::I32X4_SHL, ()),
-			I64x2Shl => simd!(writer, opcodes::I64X2_SHL, ()),
-			I8x16ShrS => simd!(writer, opcodes::I8X16_SHR_S, ()),
-			I8x16ShrU => simd!(writer, opcodes::I8X16_SHR_U, ()),
-			I16x8ShrS => simd!(writer, opcodes::I16X8_SHR_S, ()),
-			I16x8ShrU => simd!(writer, opcodes::I16X8_SHR_U, ()),
-			I32x4ShrU => simd!(writer, opcodes::I32X4_SHR_U, ()),
-			I32x4ShrS => simd!(writer, opcodes::I32X4_SHR_S, ()),
-			I64x2ShrU => simd!(writer, opcodes::I64X2_SHR_U, ()),
-			I64x2ShrS => simd!(writer, opcodes::I64X2_SHR_S, ()),
-			V128And => simd!(writer, opcodes::V128_AND, ()),
-			V128Or => simd!(writer, opcodes::V128_OR, ()),
-			V128Xor => simd!(writer, opcodes::V128_XOR, ()),
-			V128Not => simd!(writer, opcodes::V128_NOT, ()),
-			V128Bitselect => simd!(writer, opcodes::V128_BITSELECT, ()),
-			I8x16AnyTrue => simd!(writer, opcodes::I8X16_ANY_TRUE, ()),
-			I16x8AnyTrue => simd!(writer, opcodes::I16X8_ANY_TRUE, ()),
-			I32x4AnyTrue => simd!(writer, opcodes::I32X4_ANY_TRUE, ()),
-			I64x2AnyTrue => simd!(writer, opcodes::I64X2_ANY_TRUE, ()),
-			I8x16AllTrue => simd!(writer, opcodes::I8X16_ALL_TRUE, ()),
-			I16x8AllTrue => simd!(writer, opcodes::I16X8_ALL_TRUE, ()),
-			I32x4AllTrue => simd!(writer, opcodes::I32X4_ALL_TRUE, ()),
-			I64x2AllTrue => simd!(writer, opcodes::I64X2_ALL_TRUE, ()),
-			I8x16Eq => simd!(writer, opcodes::I8X16_EQ, ()),
-			I16x8Eq => simd!(writer, opcodes::I16X8_EQ, ()),
-			I32x4Eq => simd!(writer, opcodes::I32X4_EQ, ()),
-			// I64x2Eq => simd!(writer, opcodes::I64X2_EQ, ()),
-			F32x4Eq => simd!(writer, opcodes::F32X4_EQ, ()),
-			F64x2Eq => simd!(writer, opcodes::F64X2_EQ, ()),
-			I8x16Ne => simd!(writer, opcodes::I8X16_NE, ()),
-			I16x8Ne => simd!(writer, opcodes::I16X8_NE, ()),
-			I32x4Ne => simd!(writer, opcodes::I32X4_NE, ()),
-			// I64x2Ne => simd!(writer, opcodes::I64X2_NE, ()),
-			F32x4Ne => simd!(writer, opcodes::F32X4_NE, ()),
-			F64x2Ne => simd!(writer, opcodes::F64X2_NE, ()),
-			I8x16LtS => simd!(writer, opcodes::I8X16_LT_S, ()),
-			I8x16LtU => simd!(writer, opcodes::I8X16_LT_U, ()),
-			I16x8LtS => simd!(writer, opcodes::I16X8_LT_S, ()),
-			I16x8LtU => simd!(writer, opcodes::I16X8_LT_U, ()),
-			I32x4LtS => simd!(writer, opcodes::I32X4_LT_S, ()),
-			I32x4LtU => simd!(writer, opcodes::I32X4_LT_U, ()),
-			// I64x2LtS => simd!(writer, opcodes::I64X2_LT_S, ()),
-			// I64x2LtU => simd!(writer, opcodes::I64X2_LT_U, ()),
-			F32x4Lt => simd!(writer, opcodes::F32X4_LT, ()),
-			F64x2Lt => simd!(writer, opcodes::F64X2_LT, ()),
-			I8x16LeS => simd!(writer, opcodes::I8X16_LE_S, ()),
-			I8x16LeU => simd!(writer, opcodes::I8X16_LE_U, ()),
-			I16x8LeS => simd!(writer, opcodes::I16X8_LE_S, ()),
-			I16x8LeU => simd!(writer, opcodes::I16X8_LE_U, ()),
-			I32x4LeS => simd!(writer, opcodes::I32X4_LE_S, ()),
-			I32x4LeU => simd!(writer, opcodes::I32X4_LE_U, ()),
-			// I64x2LeS => simd!(writer, opcodes::I64X2_LE_S, ()),
-			// I64x2LeU => simd!(writer, opcodes::I64X2_LE_U, ()),
-			F32x4Le => simd!(writer, opcodes::F32X4_LE, ()),
-			F64x2Le => simd!(writer, opcodes::F64X2_LE, ()),
-			I8x16GtS => simd!(writer, opcodes::I8X16_GT_S, ()),
-			I8x16GtU => simd!(writer, opcodes::I8X16_GT_U, ()),
-			I16x8GtS => simd!(writer, opcodes::I16X8_GT_S, ()),
-			I16x8GtU => simd!(writer, opcodes::I16X8_GT_U, ()),
-			I32x4GtS => simd!(writer, opcodes::I32X4_GT_S, ()),
-			I32x4GtU => simd!(writer, opcodes::I32X4_GT_U, ()),
-			// I64x2GtS => simd!(writer, opcodes::I64X2_GT_S, ()),
-			// I64x2GtU => simd!(writer, opcodes::I64X2_GT_U, ()),
-			F32x4Gt => simd!(writer, opcodes::F32X4_GT, ()),
-			F64x2Gt => simd!(writer, opcodes::F64X2_GT, ()),
-			I8x16GeS => simd!(writer, opcodes::I8X16_GE_S, ()),
-			I8x16GeU => simd!(writer, opcodes::I8X16_GE_U, ()),
-			I16x8GeS => simd!(writer, opcodes::I16X8_GE_S, ()),
-			I16x8GeU => simd!(writer, opcodes::I16X8_GE_U, ()),
-			I32x4GeS => simd!(writer, opcodes::I32X4_GE_S, ()),
-			I32x4GeU => simd!(writer, opcodes::I32X4_GE_U, ()),
-			// I64x2GeS => simd!(writer, opcodes::I64X2_GE_S, ()),
-			// I64x2GeU => simd!(writer, opcodes::I64X2_GE_U, ()),
-			F32x4Ge => simd!(writer, opcodes::F32X4_GE, ()),
-			F64x2Ge => simd!(writer, opcodes::F64X2_GE, ()),
-			F32x4Neg => simd!(writer, opcodes::F32X4_NEG, ()),
-			F64x2Neg => simd!(writer, opcodes::F64X2_NEG, ()),
-			F32x4Abs => simd!(writer, opcodes::F32X4_ABS, ()),
-			F64x2Abs => simd!(writer, opcodes::F64X2_ABS, ()),
-			F32x4Min => simd!(writer, opcodes::F32X4_MIN, ()),
-			F64x2Min => simd!(writer, opcodes::F64X2_MIN, ()),
-			F32x4Max => simd!(writer, opcodes::F32X4_MAX, ()),
-			F64x2Max => simd!(writer, opcodes::F64X2_MAX, ()),
-			F32x4Add => simd!(writer, opcodes::F32X4_ADD, ()),
-			F64x2Add => simd!(writer, opcodes::F64X2_ADD, ()),
-			F32x4Sub => simd!(writer, opcodes::F32X4_SUB, ()),
-			F64x2Sub => simd!(writer, opcodes::F64X2_SUB, ()),
-			F32x4Div => simd!(writer, opcodes::F32X4_DIV, ()),
-			F64x2Div => simd!(writer, opcodes::F64X2_DIV, ()),
-			F32x4Mul => simd!(writer, opcodes::F32X4_MUL, ()),
-			F64x2Mul => simd!(writer, opcodes::F64X2_MUL, ()),
-			F32x4Sqrt => simd!(writer, opcodes::F32X4_SQRT, ()),
-			F64x2Sqrt => simd!(writer, opcodes::F64X2_SQRT, ()),
-			F32x4ConvertSI32x4 => simd!(writer, opcodes::F32X4_CONVERT_S_I32X4, ()),
-			F32x4ConvertUI32x4 => simd!(writer, opcodes::F32X4_CONVERT_U_I32X4, ()),
-			F64x2ConvertSI64x2 => simd!(writer, opcodes::F64X2_CONVERT_S_I64X2, ()),
-			F64x2ConvertUI64x2 => simd!(writer, opcodes::F64X2_CONVERT_U_I64X2, ()),
-			I32x4TruncSF32x4Sat => simd!(writer, opcodes::I32X4_TRUNC_S_F32X4_SAT, ()),
-			I32x4TruncUF32x4Sat => simd!(writer, opcodes::I32X4_TRUNC_U_F32X4_SAT, ()),
-			I64x2TruncSF64x2Sat => simd!(writer, opcodes::I64X2_TRUNC_S_F64X2_SAT, ()),
-			I64x2TruncUF64x2Sat => simd!(writer, opcodes::I64X2_TRUNC_U_F64X2_SAT, ()),
+			V128Const(ref c) => simd!(writer, V128_CONST, writer.write(&c[..])?),
+			V128Load(m) => simd!(writer, V128_LOAD, MemArg::serialize(m, writer)?),
+			V128Store(m) => simd!(writer, V128_STORE, MemArg::serialize(m, writer)?),
+			I8x16Splat => simd!(writer, I8X16_SPLAT, ()),
+			I16x8Splat => simd!(writer, I16X8_SPLAT, ()),
+			I32x4Splat => simd!(writer, I32X4_SPLAT, ()),
+			I64x2Splat => simd!(writer, I64X2_SPLAT, ()),
+			F32x4Splat => simd!(writer, F32X4_SPLAT, ()),
+			F64x2Splat => simd!(writer, F64X2_SPLAT, ()),
+			I8x16ExtractLaneS(i) => simd!(writer, I8X16_EXTRACT_LANE_S, writer.write(&[i])?),
+			I8x16ExtractLaneU(i) => simd!(writer, I8X16_EXTRACT_LANE_U, writer.write(&[i])?),
+			I16x8ExtractLaneS(i) => simd!(writer, I16X8_EXTRACT_LANE_S, writer.write(&[i])?),
+			I16x8ExtractLaneU(i) => simd!(writer, I16X8_EXTRACT_LANE_U, writer.write(&[i])?),
+			I32x4ExtractLane(i) => simd!(writer, I32X4_EXTRACT_LANE, writer.write(&[i])?),
+			I64x2ExtractLane(i) => simd!(writer, I64X2_EXTRACT_LANE, writer.write(&[i])?),
+			F32x4ExtractLane(i) => simd!(writer, F32X4_EXTRACT_LANE, writer.write(&[i])?),
+			F64x2ExtractLane(i) => simd!(writer, F64X2_EXTRACT_LANE, writer.write(&[i])?),
+			I8x16ReplaceLane(i) => simd!(writer, I8X16_REPLACE_LANE, writer.write(&[i])?),
+			I16x8ReplaceLane(i) => simd!(writer, I16X8_REPLACE_LANE, writer.write(&[i])?),
+			I32x4ReplaceLane(i) => simd!(writer, I32X4_REPLACE_LANE, writer.write(&[i])?),
+			I64x2ReplaceLane(i) => simd!(writer, I64X2_REPLACE_LANE, writer.write(&[i])?),
+			F32x4ReplaceLane(i) => simd!(writer, F32X4_REPLACE_LANE, writer.write(&[i])?),
+			F64x2ReplaceLane(i) => simd!(writer, F64X2_REPLACE_LANE, writer.write(&[i])?),
+			V8x16Shuffle(ref i) => simd!(writer, V8X16_SHUFFLE, writer.write(&i[..])?),
+			I8x16Add => simd!(writer, I8X16_ADD, ()),
+			I16x8Add => simd!(writer, I16X8_ADD, ()),
+			I32x4Add => simd!(writer, I32X4_ADD, ()),
+			I64x2Add => simd!(writer, I64X2_ADD, ()),
+			I8x16Sub => simd!(writer, I8X16_SUB, ()),
+			I16x8Sub => simd!(writer, I16X8_SUB, ()),
+			I32x4Sub => simd!(writer, I32X4_SUB, ()),
+			I64x2Sub => simd!(writer, I64X2_SUB, ()),
+			I8x16Mul => simd!(writer, I8X16_MUL, ()),
+			I16x8Mul => simd!(writer, I16X8_MUL, ()),
+			I32x4Mul => simd!(writer, I32X4_MUL, ()),
+			// I64x2Mul => simd!(writer, I64X2_MUL, ()),
+			I8x16Neg => simd!(writer, I8X16_NEG, ()),
+			I16x8Neg => simd!(writer, I16X8_NEG, ()),
+			I32x4Neg => simd!(writer, I32X4_NEG, ()),
+			I64x2Neg => simd!(writer, I64X2_NEG, ()),
+			I8x16AddSaturateS => simd!(writer, I8X16_ADD_SATURATE_S, ()),
+			I8x16AddSaturateU => simd!(writer, I8X16_ADD_SATURATE_U, ()),
+			I16x8AddSaturateS => simd!(writer, I16X8_ADD_SATURATE_S, ()),
+			I16x8AddSaturateU => simd!(writer, I16X8_ADD_SATURATE_U, ()),
+			I8x16SubSaturateS => simd!(writer, I8X16_SUB_SATURATE_S, ()),
+			I8x16SubSaturateU => simd!(writer, I8X16_SUB_SATURATE_U, ()),
+			I16x8SubSaturateS => simd!(writer, I16X8_SUB_SATURATE_S, ()),
+			I16x8SubSaturateU => simd!(writer, I16X8_SUB_SATURATE_U, ()),
+			I8x16Shl => simd!(writer, I8X16_SHL, ()),
+			I16x8Shl => simd!(writer, I16X8_SHL, ()),
+			I32x4Shl => simd!(writer, I32X4_SHL, ()),
+			I64x2Shl => simd!(writer, I64X2_SHL, ()),
+			I8x16ShrS => simd!(writer, I8X16_SHR_S, ()),
+			I8x16ShrU => simd!(writer, I8X16_SHR_U, ()),
+			I16x8ShrS => simd!(writer, I16X8_SHR_S, ()),
+			I16x8ShrU => simd!(writer, I16X8_SHR_U, ()),
+			I32x4ShrU => simd!(writer, I32X4_SHR_U, ()),
+			I32x4ShrS => simd!(writer, I32X4_SHR_S, ()),
+			I64x2ShrU => simd!(writer, I64X2_SHR_U, ()),
+			I64x2ShrS => simd!(writer, I64X2_SHR_S, ()),
+			V128And => simd!(writer, V128_AND, ()),
+			V128Or => simd!(writer, V128_OR, ()),
+			V128Xor => simd!(writer, V128_XOR, ()),
+			V128Not => simd!(writer, V128_NOT, ()),
+			V128Bitselect => simd!(writer, V128_BITSELECT, ()),
+			I8x16AnyTrue => simd!(writer, I8X16_ANY_TRUE, ()),
+			I16x8AnyTrue => simd!(writer, I16X8_ANY_TRUE, ()),
+			I32x4AnyTrue => simd!(writer, I32X4_ANY_TRUE, ()),
+			I64x2AnyTrue => simd!(writer, I64X2_ANY_TRUE, ()),
+			I8x16AllTrue => simd!(writer, I8X16_ALL_TRUE, ()),
+			I16x8AllTrue => simd!(writer, I16X8_ALL_TRUE, ()),
+			I32x4AllTrue => simd!(writer, I32X4_ALL_TRUE, ()),
+			I64x2AllTrue => simd!(writer, I64X2_ALL_TRUE, ()),
+			I8x16Eq => simd!(writer, I8X16_EQ, ()),
+			I16x8Eq => simd!(writer, I16X8_EQ, ()),
+			I32x4Eq => simd!(writer, I32X4_EQ, ()),
+			// I64x2Eq => simd!(writer, I64X2_EQ, ()),
+			F32x4Eq => simd!(writer, F32X4_EQ, ()),
+			F64x2Eq => simd!(writer, F64X2_EQ, ()),
+			I8x16Ne => simd!(writer, I8X16_NE, ()),
+			I16x8Ne => simd!(writer, I16X8_NE, ()),
+			I32x4Ne => simd!(writer, I32X4_NE, ()),
+			// I64x2Ne => simd!(writer, I64X2_NE, ()),
+			F32x4Ne => simd!(writer, F32X4_NE, ()),
+			F64x2Ne => simd!(writer, F64X2_NE, ()),
+			I8x16LtS => simd!(writer, I8X16_LT_S, ()),
+			I8x16LtU => simd!(writer, I8X16_LT_U, ()),
+			I16x8LtS => simd!(writer, I16X8_LT_S, ()),
+			I16x8LtU => simd!(writer, I16X8_LT_U, ()),
+			I32x4LtS => simd!(writer, I32X4_LT_S, ()),
+			I32x4LtU => simd!(writer, I32X4_LT_U, ()),
+			// I64x2LtS => simd!(writer, I64X2_LT_S, ()),
+			// I64x2LtU => simd!(writer, I64X2_LT_U, ()),
+			F32x4Lt => simd!(writer, F32X4_LT, ()),
+			F64x2Lt => simd!(writer, F64X2_LT, ()),
+			I8x16LeS => simd!(writer, I8X16_LE_S, ()),
+			I8x16LeU => simd!(writer, I8X16_LE_U, ()),
+			I16x8LeS => simd!(writer, I16X8_LE_S, ()),
+			I16x8LeU => simd!(writer, I16X8_LE_U, ()),
+			I32x4LeS => simd!(writer, I32X4_LE_S, ()),
+			I32x4LeU => simd!(writer, I32X4_LE_U, ()),
+			// I64x2LeS => simd!(writer, I64X2_LE_S, ()),
+			// I64x2LeU => simd!(writer, I64X2_LE_U, ()),
+			F32x4Le => simd!(writer, F32X4_LE, ()),
+			F64x2Le => simd!(writer, F64X2_LE, ()),
+			I8x16GtS => simd!(writer, I8X16_GT_S, ()),
+			I8x16GtU => simd!(writer, I8X16_GT_U, ()),
+			I16x8GtS => simd!(writer, I16X8_GT_S, ()),
+			I16x8GtU => simd!(writer, I16X8_GT_U, ()),
+			I32x4GtS => simd!(writer, I32X4_GT_S, ()),
+			I32x4GtU => simd!(writer, I32X4_GT_U, ()),
+			// I64x2GtS => simd!(writer, I64X2_GT_S, ()),
+			// I64x2GtU => simd!(writer, I64X2_GT_U, ()),
+			F32x4Gt => simd!(writer, F32X4_GT, ()),
+			F64x2Gt => simd!(writer, F64X2_GT, ()),
+			I8x16GeS => simd!(writer, I8X16_GE_S, ()),
+			I8x16GeU => simd!(writer, I8X16_GE_U, ()),
+			I16x8GeS => simd!(writer, I16X8_GE_S, ()),
+			I16x8GeU => simd!(writer, I16X8_GE_U, ()),
+			I32x4GeS => simd!(writer, I32X4_GE_S, ()),
+			I32x4GeU => simd!(writer, I32X4_GE_U, ()),
+			// I64x2GeS => simd!(writer, I64X2_GE_S, ()),
+			// I64x2GeU => simd!(writer, I64X2_GE_U, ()),
+			F32x4Ge => simd!(writer, F32X4_GE, ()),
+			F64x2Ge => simd!(writer, F64X2_GE, ()),
+			F32x4Neg => simd!(writer, F32X4_NEG, ()),
+			F64x2Neg => simd!(writer, F64X2_NEG, ()),
+			F32x4Abs => simd!(writer, F32X4_ABS, ()),
+			F64x2Abs => simd!(writer, F64X2_ABS, ()),
+			F32x4Min => simd!(writer, F32X4_MIN, ()),
+			F64x2Min => simd!(writer, F64X2_MIN, ()),
+			F32x4Max => simd!(writer, F32X4_MAX, ()),
+			F64x2Max => simd!(writer, F64X2_MAX, ()),
+			F32x4Add => simd!(writer, F32X4_ADD, ()),
+			F64x2Add => simd!(writer, F64X2_ADD, ()),
+			F32x4Sub => simd!(writer, F32X4_SUB, ()),
+			F64x2Sub => simd!(writer, F64X2_SUB, ()),
+			F32x4Div => simd!(writer, F32X4_DIV, ()),
+			F64x2Div => simd!(writer, F64X2_DIV, ()),
+			F32x4Mul => simd!(writer, F32X4_MUL, ()),
+			F64x2Mul => simd!(writer, F64X2_MUL, ()),
+			F32x4Sqrt => simd!(writer, F32X4_SQRT, ()),
+			F64x2Sqrt => simd!(writer, F64X2_SQRT, ()),
+			F32x4ConvertSI32x4 => simd!(writer, F32X4_CONVERT_S_I32X4, ()),
+			F32x4ConvertUI32x4 => simd!(writer, F32X4_CONVERT_U_I32X4, ()),
+			F64x2ConvertSI64x2 => simd!(writer, F64X2_CONVERT_S_I64X2, ()),
+			F64x2ConvertUI64x2 => simd!(writer, F64X2_CONVERT_U_I64X2, ()),
+			I32x4TruncSF32x4Sat => simd!(writer, I32X4_TRUNC_S_F32X4_SAT, ()),
+			I32x4TruncUF32x4Sat => simd!(writer, I32X4_TRUNC_U_F32X4_SAT, ()),
+			I64x2TruncSF64x2Sat => simd!(writer, I64X2_TRUNC_S_F64X2_SAT, ()),
+			I64x2TruncUF64x2Sat => simd!(writer, I64X2_TRUNC_U_F64X2_SAT, ()),
 		}
 
 		Ok(())
@@ -2293,7 +2307,7 @@ impl Serialize for BulkInstruction {
 
 	fn serialize<W: io::Write>(self, writer: &mut W) -> Result<(), Self::Error> {
 		use self::BulkInstruction::*;
-		use self::opcodes::*;
+		use self::opcodes::bulk::*;
 
 		match self {
 			MemoryInit(seg) => bulk!(writer, MEMORY_INIT, {

--- a/src/elements/ops.rs
+++ b/src/elements/ops.rs
@@ -303,6 +303,101 @@ pub enum Instruction {
 	#[cfg(feature="atomics")]
 	Atomics(AtomicsInstruction),
 
+	#[cfg(feature="simd")]
+	Simd(SimdInstruction),
+
+	// https://github.com/WebAssembly/bulk-memory-operations
+	MemoryInit(u32),
+	MemoryDrop(u32),
+	MemoryCopy,
+	MemoryFill,
+	TableInit(u32),
+	TableDrop(u32),
+	TableCopy,
+}
+
+#[cfg(feature="atomics")]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum AtomicsInstruction {
+	AtomicWake(MemArg),
+	I32AtomicWait(MemArg),
+	I64AtomicWait(MemArg),
+
+	I32AtomicLoad(MemArg),
+	I64AtomicLoad(MemArg),
+	I32AtomicLoad8u(MemArg),
+	I32AtomicLoad16u(MemArg),
+	I64AtomicLoad8u(MemArg),
+	I64AtomicLoad16u(MemArg),
+	I64AtomicLoad32u(MemArg),
+	I32AtomicStore(MemArg),
+	I64AtomicStore(MemArg),
+	I32AtomicStore8u(MemArg),
+	I32AtomicStore16u(MemArg),
+	I64AtomicStore8u(MemArg),
+	I64AtomicStore16u(MemArg),
+	I64AtomicStore32u(MemArg),
+
+	I32AtomicRmwAdd(MemArg),
+	I64AtomicRmwAdd(MemArg),
+	I32AtomicRmwAdd8u(MemArg),
+	I32AtomicRmwAdd16u(MemArg),
+	I64AtomicRmwAdd8u(MemArg),
+	I64AtomicRmwAdd16u(MemArg),
+	I64AtomicRmwAdd32u(MemArg),
+
+	I32AtomicRmwSub(MemArg),
+	I64AtomicRmwSub(MemArg),
+	I32AtomicRmwSub8u(MemArg),
+	I32AtomicRmwSub16u(MemArg),
+	I64AtomicRmwSub8u(MemArg),
+	I64AtomicRmwSub16u(MemArg),
+	I64AtomicRmwSub32u(MemArg),
+
+	I32AtomicRmwAnd(MemArg),
+	I64AtomicRmwAnd(MemArg),
+	I32AtomicRmwAnd8u(MemArg),
+	I32AtomicRmwAnd16u(MemArg),
+	I64AtomicRmwAnd8u(MemArg),
+	I64AtomicRmwAnd16u(MemArg),
+	I64AtomicRmwAnd32u(MemArg),
+
+	I32AtomicRmwOr(MemArg),
+	I64AtomicRmwOr(MemArg),
+	I32AtomicRmwOr8u(MemArg),
+	I32AtomicRmwOr16u(MemArg),
+	I64AtomicRmwOr8u(MemArg),
+	I64AtomicRmwOr16u(MemArg),
+	I64AtomicRmwOr32u(MemArg),
+
+	I32AtomicRmwXor(MemArg),
+	I64AtomicRmwXor(MemArg),
+	I32AtomicRmwXor8u(MemArg),
+	I32AtomicRmwXor16u(MemArg),
+	I64AtomicRmwXor8u(MemArg),
+	I64AtomicRmwXor16u(MemArg),
+	I64AtomicRmwXor32u(MemArg),
+
+	I32AtomicRmwXchg(MemArg),
+	I64AtomicRmwXchg(MemArg),
+	I32AtomicRmwXchg8u(MemArg),
+	I32AtomicRmwXchg16u(MemArg),
+	I64AtomicRmwXchg8u(MemArg),
+	I64AtomicRmwXchg16u(MemArg),
+	I64AtomicRmwXchg32u(MemArg),
+
+	I32AtomicRmwCmpxchg(MemArg),
+	I64AtomicRmwCmpxchg(MemArg),
+	I32AtomicRmwCmpxchg8u(MemArg),
+	I32AtomicRmwCmpxchg16u(MemArg),
+	I64AtomicRmwCmpxchg8u(MemArg),
+	I64AtomicRmwCmpxchg16u(MemArg),
+	I64AtomicRmwCmpxchg32u(MemArg),
+}
+
+#[cfg(feature="simd")]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum SimdInstruction {
 	V128Const(Box<[u8; 16]>),
 	V128Load(MemArg),
 	V128Store(MemArg),
@@ -454,94 +549,6 @@ pub enum Instruction {
 	I32x4TruncUF32x4Sat,
 	I64x2TruncSF64x2Sat,
 	I64x2TruncUF64x2Sat,
-
-	// https://github.com/WebAssembly/bulk-memory-operations
-	MemoryInit(u32),
-	MemoryDrop(u32),
-	MemoryCopy,
-	MemoryFill,
-	TableInit(u32),
-	TableDrop(u32),
-	TableCopy,
-}
-
-#[cfg(feature="atomics")]
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub enum AtomicsInstruction {
-	AtomicWake(MemArg),
-	I32AtomicWait(MemArg),
-	I64AtomicWait(MemArg),
-
-	I32AtomicLoad(MemArg),
-	I64AtomicLoad(MemArg),
-	I32AtomicLoad8u(MemArg),
-	I32AtomicLoad16u(MemArg),
-	I64AtomicLoad8u(MemArg),
-	I64AtomicLoad16u(MemArg),
-	I64AtomicLoad32u(MemArg),
-	I32AtomicStore(MemArg),
-	I64AtomicStore(MemArg),
-	I32AtomicStore8u(MemArg),
-	I32AtomicStore16u(MemArg),
-	I64AtomicStore8u(MemArg),
-	I64AtomicStore16u(MemArg),
-	I64AtomicStore32u(MemArg),
-
-	I32AtomicRmwAdd(MemArg),
-	I64AtomicRmwAdd(MemArg),
-	I32AtomicRmwAdd8u(MemArg),
-	I32AtomicRmwAdd16u(MemArg),
-	I64AtomicRmwAdd8u(MemArg),
-	I64AtomicRmwAdd16u(MemArg),
-	I64AtomicRmwAdd32u(MemArg),
-
-	I32AtomicRmwSub(MemArg),
-	I64AtomicRmwSub(MemArg),
-	I32AtomicRmwSub8u(MemArg),
-	I32AtomicRmwSub16u(MemArg),
-	I64AtomicRmwSub8u(MemArg),
-	I64AtomicRmwSub16u(MemArg),
-	I64AtomicRmwSub32u(MemArg),
-
-	I32AtomicRmwAnd(MemArg),
-	I64AtomicRmwAnd(MemArg),
-	I32AtomicRmwAnd8u(MemArg),
-	I32AtomicRmwAnd16u(MemArg),
-	I64AtomicRmwAnd8u(MemArg),
-	I64AtomicRmwAnd16u(MemArg),
-	I64AtomicRmwAnd32u(MemArg),
-
-	I32AtomicRmwOr(MemArg),
-	I64AtomicRmwOr(MemArg),
-	I32AtomicRmwOr8u(MemArg),
-	I32AtomicRmwOr16u(MemArg),
-	I64AtomicRmwOr8u(MemArg),
-	I64AtomicRmwOr16u(MemArg),
-	I64AtomicRmwOr32u(MemArg),
-
-	I32AtomicRmwXor(MemArg),
-	I64AtomicRmwXor(MemArg),
-	I32AtomicRmwXor8u(MemArg),
-	I32AtomicRmwXor16u(MemArg),
-	I64AtomicRmwXor8u(MemArg),
-	I64AtomicRmwXor16u(MemArg),
-	I64AtomicRmwXor32u(MemArg),
-
-	I32AtomicRmwXchg(MemArg),
-	I64AtomicRmwXchg(MemArg),
-	I32AtomicRmwXchg8u(MemArg),
-	I32AtomicRmwXchg16u(MemArg),
-	I64AtomicRmwXchg8u(MemArg),
-	I64AtomicRmwXchg16u(MemArg),
-	I64AtomicRmwXchg32u(MemArg),
-
-	I32AtomicRmwCmpxchg(MemArg),
-	I64AtomicRmwCmpxchg(MemArg),
-	I32AtomicRmwCmpxchg8u(MemArg),
-	I32AtomicRmwCmpxchg16u(MemArg),
-	I64AtomicRmwCmpxchg8u(MemArg),
-	I64AtomicRmwCmpxchg16u(MemArg),
-	I64AtomicRmwCmpxchg32u(MemArg),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -1315,6 +1322,8 @@ impl Deserialize for Instruction {
 
 				#[cfg(feature="atomics")]
 				ATOMIC_PREFIX => return deserialize_atomic(reader),
+
+				#[cfg(feature="simd")]
 				SIMD_PREFIX => return deserialize_simd(reader),
 
 				BULK_PREFIX => return deserialize_bulk(reader),
@@ -1332,7 +1341,7 @@ fn deserialize_atomic<R: io::Read>(reader: &mut R) -> Result<Instruction, Error>
 
 	let val: u8 = Uint8::deserialize(reader)?.into();
 	let mem = MemArg::deserialize(reader)?;
-	let atomics_instruction = match val {
+	Ok(Instruction::Atomics(match val {
 		ATOMIC_WAKE => AtomicWake(mem),
 		I32_ATOMIC_WAIT => I32AtomicWait(mem),
 		I64_ATOMIC_WAIT => I64AtomicWait(mem),
@@ -1401,17 +1410,16 @@ fn deserialize_atomic<R: io::Read>(reader: &mut R) -> Result<Instruction, Error>
 		I64_ATOMIC_RMW_CMPXCHG32U => I64AtomicRmwCmpxchg32u(mem),
 
 		_ => return Err(Error::UnknownOpcode(val)),
-	};
-
-	Ok(Instruction::Atomics(atomics_instruction))
+	}))
 }
 
+#[cfg(feature="simd")]
 fn deserialize_simd<R: io::Read>(reader: &mut R) -> Result<Instruction, Error> {
-	use self::Instruction::*;
+	use self::SimdInstruction::*;
 	use self::opcodes::*;
 
 	let val = VarUint32::deserialize(reader)?.into();
-	Ok(match val {
+	Ok(Instruction::Simd(match val {
 		V128_CONST => {
 			let mut buf = [0; 16];
 			reader.read(&mut buf)?;
@@ -1574,7 +1582,7 @@ fn deserialize_simd<R: io::Read>(reader: &mut R) -> Result<Instruction, Error> {
 		I64X2_TRUNC_U_F64X2_SAT => I64x2TruncUF64x2Sat,
 
 		_ => return Err(Error::UnknownSimdOpcode(val)),
-	})
+	}))
 }
 
 fn deserialize_bulk<R: io::Read>(reader: &mut R) -> Result<Instruction, Error> {
@@ -1650,6 +1658,7 @@ macro_rules! atomic {
 	});
 }
 
+#[cfg(feature="simd")]
 macro_rules! simd {
 	($writer: expr, $byte: expr, $other:expr) => ({
 		$writer.write(&[SIMD_PREFIX])?;
@@ -1978,6 +1987,126 @@ impl Serialize for Instruction {
 			#[cfg(feature="atomics")]
 			Atomics(a) => return a.serialize(writer),
 
+			#[cfg(feature="simd")]
+			Simd(a) => return a.serialize(writer),
+
+			MemoryInit(seg) => bulk!(writer, MEMORY_INIT, {
+				Uint8::from(0).serialize(writer)?;
+				VarUint32::from(seg).serialize(writer)?;
+			}),
+			MemoryDrop(seg) => bulk!(writer, MEMORY_DROP, VarUint32::from(seg).serialize(writer)?),
+			MemoryFill => bulk!(writer, MEMORY_FILL, Uint8::from(0).serialize(writer)?),
+			MemoryCopy => bulk!(writer, MEMORY_COPY, Uint8::from(0).serialize(writer)?),
+			TableInit(seg) => bulk!(writer, TABLE_INIT, {
+				Uint8::from(0).serialize(writer)?;
+				VarUint32::from(seg).serialize(writer)?;
+			}),
+			TableDrop(seg) => bulk!(writer, TABLE_DROP, VarUint32::from(seg).serialize(writer)?),
+			TableCopy => bulk!(writer, TABLE_COPY, Uint8::from(0).serialize(writer)?),
+		}
+
+		Ok(())
+	}
+}
+
+#[cfg(feature="atomics")]
+impl Serialize for AtomicsInstruction {
+	type Error = Error;
+
+	fn serialize<W: io::Write>(self, writer: &mut W) -> Result<(), Self::Error> {
+		use self::AtomicsInstruction::*;
+		use self::opcodes::*;
+
+		match self {
+			AtomicWake(m) => atomic!(writer, ATOMIC_WAKE, m),
+			I32AtomicWait(m) => atomic!(writer, I32_ATOMIC_WAIT, m),
+			I64AtomicWait(m) => atomic!(writer, I64_ATOMIC_WAIT, m),
+
+			I32AtomicLoad(m) => atomic!(writer, I32_ATOMIC_LOAD, m),
+			I64AtomicLoad(m) => atomic!(writer, I64_ATOMIC_LOAD, m),
+			I32AtomicLoad8u(m) => atomic!(writer, I32_ATOMIC_LOAD8U, m),
+			I32AtomicLoad16u(m) => atomic!(writer, I32_ATOMIC_LOAD16U, m),
+			I64AtomicLoad8u(m) => atomic!(writer, I64_ATOMIC_LOAD8U, m),
+			I64AtomicLoad16u(m) => atomic!(writer, I64_ATOMIC_LOAD16U, m),
+			I64AtomicLoad32u(m) => atomic!(writer, I64_ATOMIC_LOAD32U, m),
+			I32AtomicStore(m) => atomic!(writer, I32_ATOMIC_STORE, m),
+			I64AtomicStore(m) => atomic!(writer, I64_ATOMIC_STORE, m),
+			I32AtomicStore8u(m) => atomic!(writer, I32_ATOMIC_STORE8U, m),
+			I32AtomicStore16u(m) => atomic!(writer, I32_ATOMIC_STORE16U, m),
+			I64AtomicStore8u(m) => atomic!(writer, I64_ATOMIC_STORE8U, m),
+			I64AtomicStore16u(m) => atomic!(writer, I64_ATOMIC_STORE16U, m),
+			I64AtomicStore32u(m) => atomic!(writer, I64_ATOMIC_STORE32U, m),
+
+			I32AtomicRmwAdd(m) => atomic!(writer, I32_ATOMIC_RMW_ADD, m),
+			I64AtomicRmwAdd(m) => atomic!(writer, I64_ATOMIC_RMW_ADD, m),
+			I32AtomicRmwAdd8u(m) => atomic!(writer, I32_ATOMIC_RMW_ADD8U, m),
+			I32AtomicRmwAdd16u(m) => atomic!(writer, I32_ATOMIC_RMW_ADD16U, m),
+			I64AtomicRmwAdd8u(m) => atomic!(writer, I64_ATOMIC_RMW_ADD8U, m),
+			I64AtomicRmwAdd16u(m) => atomic!(writer, I64_ATOMIC_RMW_ADD16U, m),
+			I64AtomicRmwAdd32u(m) => atomic!(writer, I64_ATOMIC_RMW_ADD32U, m),
+
+			I32AtomicRmwSub(m) => atomic!(writer, I32_ATOMIC_RMW_SUB, m),
+			I64AtomicRmwSub(m) => atomic!(writer, I64_ATOMIC_RMW_SUB, m),
+			I32AtomicRmwSub8u(m) => atomic!(writer, I32_ATOMIC_RMW_SUB8U, m),
+			I32AtomicRmwSub16u(m) => atomic!(writer, I32_ATOMIC_RMW_SUB16U, m),
+			I64AtomicRmwSub8u(m) => atomic!(writer, I64_ATOMIC_RMW_SUB8U, m),
+			I64AtomicRmwSub16u(m) => atomic!(writer, I64_ATOMIC_RMW_SUB16U, m),
+			I64AtomicRmwSub32u(m) => atomic!(writer, I64_ATOMIC_RMW_SUB32U, m),
+
+			I32AtomicRmwAnd(m) => atomic!(writer, I32_ATOMIC_RMW_AND, m),
+			I64AtomicRmwAnd(m) => atomic!(writer, I64_ATOMIC_RMW_AND, m),
+			I32AtomicRmwAnd8u(m) => atomic!(writer, I32_ATOMIC_RMW_AND8U, m),
+			I32AtomicRmwAnd16u(m) => atomic!(writer, I32_ATOMIC_RMW_AND16U, m),
+			I64AtomicRmwAnd8u(m) => atomic!(writer, I64_ATOMIC_RMW_AND8U, m),
+			I64AtomicRmwAnd16u(m) => atomic!(writer, I64_ATOMIC_RMW_AND16U, m),
+			I64AtomicRmwAnd32u(m) => atomic!(writer, I64_ATOMIC_RMW_AND32U, m),
+
+			I32AtomicRmwOr(m) => atomic!(writer, I32_ATOMIC_RMW_OR, m),
+			I64AtomicRmwOr(m) => atomic!(writer, I64_ATOMIC_RMW_OR, m),
+			I32AtomicRmwOr8u(m) => atomic!(writer, I32_ATOMIC_RMW_OR8U, m),
+			I32AtomicRmwOr16u(m) => atomic!(writer, I32_ATOMIC_RMW_OR16U, m),
+			I64AtomicRmwOr8u(m) => atomic!(writer, I64_ATOMIC_RMW_OR8U, m),
+			I64AtomicRmwOr16u(m) => atomic!(writer, I64_ATOMIC_RMW_OR16U, m),
+			I64AtomicRmwOr32u(m) => atomic!(writer, I64_ATOMIC_RMW_OR32U, m),
+
+			I32AtomicRmwXor(m) => atomic!(writer, I32_ATOMIC_RMW_XOR, m),
+			I64AtomicRmwXor(m) => atomic!(writer, I64_ATOMIC_RMW_XOR, m),
+			I32AtomicRmwXor8u(m) => atomic!(writer, I32_ATOMIC_RMW_XOR8U, m),
+			I32AtomicRmwXor16u(m) => atomic!(writer, I32_ATOMIC_RMW_XOR16U, m),
+			I64AtomicRmwXor8u(m) => atomic!(writer, I64_ATOMIC_RMW_XOR8U, m),
+			I64AtomicRmwXor16u(m) => atomic!(writer, I64_ATOMIC_RMW_XOR16U, m),
+			I64AtomicRmwXor32u(m) => atomic!(writer, I64_ATOMIC_RMW_XOR32U, m),
+
+			I32AtomicRmwXchg(m) => atomic!(writer, I32_ATOMIC_RMW_XCHG, m),
+			I64AtomicRmwXchg(m) => atomic!(writer, I64_ATOMIC_RMW_XCHG, m),
+			I32AtomicRmwXchg8u(m) => atomic!(writer, I32_ATOMIC_RMW_XCHG8U, m),
+			I32AtomicRmwXchg16u(m) => atomic!(writer, I32_ATOMIC_RMW_XCHG16U, m),
+			I64AtomicRmwXchg8u(m) => atomic!(writer, I64_ATOMIC_RMW_XCHG8U, m),
+			I64AtomicRmwXchg16u(m) => atomic!(writer, I64_ATOMIC_RMW_XCHG16U, m),
+			I64AtomicRmwXchg32u(m) => atomic!(writer, I64_ATOMIC_RMW_XCHG32U, m),
+
+			I32AtomicRmwCmpxchg(m) => atomic!(writer, I32_ATOMIC_RMW_CMPXCHG, m),
+			I64AtomicRmwCmpxchg(m) => atomic!(writer, I64_ATOMIC_RMW_CMPXCHG, m),
+			I32AtomicRmwCmpxchg8u(m) => atomic!(writer, I32_ATOMIC_RMW_CMPXCHG8U, m),
+			I32AtomicRmwCmpxchg16u(m) => atomic!(writer, I32_ATOMIC_RMW_CMPXCHG16U, m),
+			I64AtomicRmwCmpxchg8u(m) => atomic!(writer, I64_ATOMIC_RMW_CMPXCHG8U, m),
+			I64AtomicRmwCmpxchg16u(m) => atomic!(writer, I64_ATOMIC_RMW_CMPXCHG16U, m),
+			I64AtomicRmwCmpxchg32u(m) => atomic!(writer, I64_ATOMIC_RMW_CMPXCHG32U, m),
+		}
+
+		Ok(())
+	}
+}
+
+#[cfg(feature="simd")]
+impl Serialize for SimdInstruction {
+	type Error = Error;
+
+	fn serialize<W: io::Write>(self, writer: &mut W) -> Result<(), Self::Error> {
+		use self::SimdInstruction::*;
+		use self::opcodes::*;
+
+		match self {
 			V128Const(ref c) => simd!(writer, opcodes::V128_CONST, writer.write(&c[..])?),
 			V128Load(m) => simd!(writer, opcodes::V128_LOAD, MemArg::serialize(m, writer)?),
 			V128Store(m) => simd!(writer, opcodes::V128_STORE, MemArg::serialize(m, writer)?),
@@ -2129,109 +2258,6 @@ impl Serialize for Instruction {
 			I32x4TruncUF32x4Sat => simd!(writer, opcodes::I32X4_TRUNC_U_F32X4_SAT, ()),
 			I64x2TruncSF64x2Sat => simd!(writer, opcodes::I64X2_TRUNC_S_F64X2_SAT, ()),
 			I64x2TruncUF64x2Sat => simd!(writer, opcodes::I64X2_TRUNC_U_F64X2_SAT, ()),
-
-			MemoryInit(seg) => bulk!(writer, MEMORY_INIT, {
-				Uint8::from(0).serialize(writer)?;
-				VarUint32::from(seg).serialize(writer)?;
-			}),
-			MemoryDrop(seg) => bulk!(writer, MEMORY_DROP, VarUint32::from(seg).serialize(writer)?),
-			MemoryFill => bulk!(writer, MEMORY_FILL, Uint8::from(0).serialize(writer)?),
-			MemoryCopy => bulk!(writer, MEMORY_COPY, Uint8::from(0).serialize(writer)?),
-			TableInit(seg) => bulk!(writer, TABLE_INIT, {
-				Uint8::from(0).serialize(writer)?;
-				VarUint32::from(seg).serialize(writer)?;
-			}),
-			TableDrop(seg) => bulk!(writer, TABLE_DROP, VarUint32::from(seg).serialize(writer)?),
-			TableCopy => bulk!(writer, TABLE_COPY, Uint8::from(0).serialize(writer)?),
-		}
-
-		Ok(())
-	}
-}
-
-#[cfg(feature="atomics")]
-impl Serialize for AtomicsInstruction {
-	type Error = Error;
-
-	fn serialize<W: io::Write>(self, writer: &mut W) -> Result<(), Self::Error> {
-		use self::AtomicsInstruction::*;
-		use self::opcodes::*;
-
-		match self {
-			AtomicWake(m) => atomic!(writer, ATOMIC_WAKE, m),
-			I32AtomicWait(m) => atomic!(writer, I32_ATOMIC_WAIT, m),
-			I64AtomicWait(m) => atomic!(writer, I64_ATOMIC_WAIT, m),
-
-			I32AtomicLoad(m) => atomic!(writer, I32_ATOMIC_LOAD, m),
-			I64AtomicLoad(m) => atomic!(writer, I64_ATOMIC_LOAD, m),
-			I32AtomicLoad8u(m) => atomic!(writer, I32_ATOMIC_LOAD8U, m),
-			I32AtomicLoad16u(m) => atomic!(writer, I32_ATOMIC_LOAD16U, m),
-			I64AtomicLoad8u(m) => atomic!(writer, I64_ATOMIC_LOAD8U, m),
-			I64AtomicLoad16u(m) => atomic!(writer, I64_ATOMIC_LOAD16U, m),
-			I64AtomicLoad32u(m) => atomic!(writer, I64_ATOMIC_LOAD32U, m),
-			I32AtomicStore(m) => atomic!(writer, I32_ATOMIC_STORE, m),
-			I64AtomicStore(m) => atomic!(writer, I64_ATOMIC_STORE, m),
-			I32AtomicStore8u(m) => atomic!(writer, I32_ATOMIC_STORE8U, m),
-			I32AtomicStore16u(m) => atomic!(writer, I32_ATOMIC_STORE16U, m),
-			I64AtomicStore8u(m) => atomic!(writer, I64_ATOMIC_STORE8U, m),
-			I64AtomicStore16u(m) => atomic!(writer, I64_ATOMIC_STORE16U, m),
-			I64AtomicStore32u(m) => atomic!(writer, I64_ATOMIC_STORE32U, m),
-
-			I32AtomicRmwAdd(m) => atomic!(writer, I32_ATOMIC_RMW_ADD, m),
-			I64AtomicRmwAdd(m) => atomic!(writer, I64_ATOMIC_RMW_ADD, m),
-			I32AtomicRmwAdd8u(m) => atomic!(writer, I32_ATOMIC_RMW_ADD8U, m),
-			I32AtomicRmwAdd16u(m) => atomic!(writer, I32_ATOMIC_RMW_ADD16U, m),
-			I64AtomicRmwAdd8u(m) => atomic!(writer, I64_ATOMIC_RMW_ADD8U, m),
-			I64AtomicRmwAdd16u(m) => atomic!(writer, I64_ATOMIC_RMW_ADD16U, m),
-			I64AtomicRmwAdd32u(m) => atomic!(writer, I64_ATOMIC_RMW_ADD32U, m),
-
-			I32AtomicRmwSub(m) => atomic!(writer, I32_ATOMIC_RMW_SUB, m),
-			I64AtomicRmwSub(m) => atomic!(writer, I64_ATOMIC_RMW_SUB, m),
-			I32AtomicRmwSub8u(m) => atomic!(writer, I32_ATOMIC_RMW_SUB8U, m),
-			I32AtomicRmwSub16u(m) => atomic!(writer, I32_ATOMIC_RMW_SUB16U, m),
-			I64AtomicRmwSub8u(m) => atomic!(writer, I64_ATOMIC_RMW_SUB8U, m),
-			I64AtomicRmwSub16u(m) => atomic!(writer, I64_ATOMIC_RMW_SUB16U, m),
-			I64AtomicRmwSub32u(m) => atomic!(writer, I64_ATOMIC_RMW_SUB32U, m),
-
-			I32AtomicRmwAnd(m) => atomic!(writer, I32_ATOMIC_RMW_AND, m),
-			I64AtomicRmwAnd(m) => atomic!(writer, I64_ATOMIC_RMW_AND, m),
-			I32AtomicRmwAnd8u(m) => atomic!(writer, I32_ATOMIC_RMW_AND8U, m),
-			I32AtomicRmwAnd16u(m) => atomic!(writer, I32_ATOMIC_RMW_AND16U, m),
-			I64AtomicRmwAnd8u(m) => atomic!(writer, I64_ATOMIC_RMW_AND8U, m),
-			I64AtomicRmwAnd16u(m) => atomic!(writer, I64_ATOMIC_RMW_AND16U, m),
-			I64AtomicRmwAnd32u(m) => atomic!(writer, I64_ATOMIC_RMW_AND32U, m),
-
-			I32AtomicRmwOr(m) => atomic!(writer, I32_ATOMIC_RMW_OR, m),
-			I64AtomicRmwOr(m) => atomic!(writer, I64_ATOMIC_RMW_OR, m),
-			I32AtomicRmwOr8u(m) => atomic!(writer, I32_ATOMIC_RMW_OR8U, m),
-			I32AtomicRmwOr16u(m) => atomic!(writer, I32_ATOMIC_RMW_OR16U, m),
-			I64AtomicRmwOr8u(m) => atomic!(writer, I64_ATOMIC_RMW_OR8U, m),
-			I64AtomicRmwOr16u(m) => atomic!(writer, I64_ATOMIC_RMW_OR16U, m),
-			I64AtomicRmwOr32u(m) => atomic!(writer, I64_ATOMIC_RMW_OR32U, m),
-
-			I32AtomicRmwXor(m) => atomic!(writer, I32_ATOMIC_RMW_XOR, m),
-			I64AtomicRmwXor(m) => atomic!(writer, I64_ATOMIC_RMW_XOR, m),
-			I32AtomicRmwXor8u(m) => atomic!(writer, I32_ATOMIC_RMW_XOR8U, m),
-			I32AtomicRmwXor16u(m) => atomic!(writer, I32_ATOMIC_RMW_XOR16U, m),
-			I64AtomicRmwXor8u(m) => atomic!(writer, I64_ATOMIC_RMW_XOR8U, m),
-			I64AtomicRmwXor16u(m) => atomic!(writer, I64_ATOMIC_RMW_XOR16U, m),
-			I64AtomicRmwXor32u(m) => atomic!(writer, I64_ATOMIC_RMW_XOR32U, m),
-
-			I32AtomicRmwXchg(m) => atomic!(writer, I32_ATOMIC_RMW_XCHG, m),
-			I64AtomicRmwXchg(m) => atomic!(writer, I64_ATOMIC_RMW_XCHG, m),
-			I32AtomicRmwXchg8u(m) => atomic!(writer, I32_ATOMIC_RMW_XCHG8U, m),
-			I32AtomicRmwXchg16u(m) => atomic!(writer, I32_ATOMIC_RMW_XCHG16U, m),
-			I64AtomicRmwXchg8u(m) => atomic!(writer, I64_ATOMIC_RMW_XCHG8U, m),
-			I64AtomicRmwXchg16u(m) => atomic!(writer, I64_ATOMIC_RMW_XCHG16U, m),
-			I64AtomicRmwXchg32u(m) => atomic!(writer, I64_ATOMIC_RMW_XCHG32U, m),
-
-			I32AtomicRmwCmpxchg(m) => atomic!(writer, I32_ATOMIC_RMW_CMPXCHG, m),
-			I64AtomicRmwCmpxchg(m) => atomic!(writer, I64_ATOMIC_RMW_CMPXCHG, m),
-			I32AtomicRmwCmpxchg8u(m) => atomic!(writer, I32_ATOMIC_RMW_CMPXCHG8U, m),
-			I32AtomicRmwCmpxchg16u(m) => atomic!(writer, I32_ATOMIC_RMW_CMPXCHG16U, m),
-			I64AtomicRmwCmpxchg8u(m) => atomic!(writer, I64_ATOMIC_RMW_CMPXCHG8U, m),
-			I64AtomicRmwCmpxchg16u(m) => atomic!(writer, I64_ATOMIC_RMW_CMPXCHG16U, m),
-			I64AtomicRmwCmpxchg32u(m) => atomic!(writer, I64_ATOMIC_RMW_CMPXCHG32U, m),
 		}
 
 		Ok(())
@@ -2512,6 +2538,110 @@ impl fmt::Display for Instruction {
 			#[cfg(feature="atomics")]
 			Atomics(ref i) => i.fmt(f),
 
+			#[cfg(feature="simd")]
+			Simd(ref i) => i.fmt(f),
+
+			MemoryInit(_) => write!(f, "memory.init"),
+			MemoryDrop(_) => write!(f, "memory.drop"),
+			MemoryFill => write!(f, "memory.fill"),
+			MemoryCopy => write!(f, "memory.copy"),
+			TableInit(_) => write!(f, "table.init"),
+			TableDrop(_) => write!(f, "table.drop"),
+			TableCopy => write!(f, "table.copy"),
+		}
+	}
+}
+
+#[cfg(feature="atomics")]
+impl fmt::Display for AtomicsInstruction {
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+		use self::AtomicsInstruction::*;
+
+		match *self {
+			AtomicWake(_) => write!(f, "atomic.wake"),
+			I32AtomicWait(_) => write!(f, "i32.atomic.wait"),
+			I64AtomicWait(_) => write!(f, "i64.atomic.wait"),
+
+			I32AtomicLoad(_) => write!(f, "i32.atomic.load"),
+			I64AtomicLoad(_) => write!(f, "i64.atomic.load"),
+			I32AtomicLoad8u(_) => write!(f, "i32.atomic.load8_u"),
+			I32AtomicLoad16u(_) => write!(f, "i32.atomic.load16_u"),
+			I64AtomicLoad8u(_) => write!(f, "i64.atomic.load8_u"),
+			I64AtomicLoad16u(_) => write!(f, "i64.atomic.load16_u"),
+			I64AtomicLoad32u(_) => write!(f, "i64.atomic.load32_u"),
+			I32AtomicStore(_) => write!(f, "i32.atomic.store"),
+			I64AtomicStore(_) => write!(f, "i64.atomic.store"),
+			I32AtomicStore8u(_) => write!(f, "i32.atomic.store8_u"),
+			I32AtomicStore16u(_) => write!(f, "i32.atomic.store16_u"),
+			I64AtomicStore8u(_) => write!(f, "i64.atomic.store8_u"),
+			I64AtomicStore16u(_) => write!(f, "i64.atomic.store16_u"),
+			I64AtomicStore32u(_) => write!(f, "i64.atomic.store32_u"),
+
+			I32AtomicRmwAdd(_) => write!(f, "i32.atomic.rmw.add"),
+			I64AtomicRmwAdd(_) => write!(f, "i64.atomic.rmw.add"),
+			I32AtomicRmwAdd8u(_) => write!(f, "i32.atomic.rmw8_u.add"),
+			I32AtomicRmwAdd16u(_) => write!(f, "i32.atomic.rmw16_u.add"),
+			I64AtomicRmwAdd8u(_) => write!(f, "i64.atomic.rmw8_u.add"),
+			I64AtomicRmwAdd16u(_) => write!(f, "i64.atomic.rmw16_u.add"),
+			I64AtomicRmwAdd32u(_) => write!(f, "i64.atomic.rmw32_u.add"),
+
+			I32AtomicRmwSub(_) => write!(f, "i32.atomic.rmw.sub"),
+			I64AtomicRmwSub(_) => write!(f, "i64.atomic.rmw.sub"),
+			I32AtomicRmwSub8u(_) => write!(f, "i32.atomic.rmw8_u.sub"),
+			I32AtomicRmwSub16u(_) => write!(f, "i32.atomic.rmw16_u.sub"),
+			I64AtomicRmwSub8u(_) => write!(f, "i64.atomic.rmw8_u.sub"),
+			I64AtomicRmwSub16u(_) => write!(f, "i64.atomic.rmw16_u.sub"),
+			I64AtomicRmwSub32u(_) => write!(f, "i64.atomic.rmw32_u.sub"),
+
+			I32AtomicRmwAnd(_) => write!(f, "i32.atomic.rmw.and"),
+			I64AtomicRmwAnd(_) => write!(f, "i64.atomic.rmw.and"),
+			I32AtomicRmwAnd8u(_) => write!(f, "i32.atomic.rmw8_u.and"),
+			I32AtomicRmwAnd16u(_) => write!(f, "i32.atomic.rmw16_u.and"),
+			I64AtomicRmwAnd8u(_) => write!(f, "i64.atomic.rmw8_u.and"),
+			I64AtomicRmwAnd16u(_) => write!(f, "i64.atomic.rmw16_u.and"),
+			I64AtomicRmwAnd32u(_) => write!(f, "i64.atomic.rmw32_u.and"),
+
+			I32AtomicRmwOr(_) => write!(f, "i32.atomic.rmw.or"),
+			I64AtomicRmwOr(_) => write!(f, "i64.atomic.rmw.or"),
+			I32AtomicRmwOr8u(_) => write!(f, "i32.atomic.rmw8_u.or"),
+			I32AtomicRmwOr16u(_) => write!(f, "i32.atomic.rmw16_u.or"),
+			I64AtomicRmwOr8u(_) => write!(f, "i64.atomic.rmw8_u.or"),
+			I64AtomicRmwOr16u(_) => write!(f, "i64.atomic.rmw16_u.or"),
+			I64AtomicRmwOr32u(_) => write!(f, "i64.atomic.rmw32_u.or"),
+
+			I32AtomicRmwXor(_) => write!(f, "i32.atomic.rmw.xor"),
+			I64AtomicRmwXor(_) => write!(f, "i64.atomic.rmw.xor"),
+			I32AtomicRmwXor8u(_) => write!(f, "i32.atomic.rmw8_u.xor"),
+			I32AtomicRmwXor16u(_) => write!(f, "i32.atomic.rmw16_u.xor"),
+			I64AtomicRmwXor8u(_) => write!(f, "i64.atomic.rmw8_u.xor"),
+			I64AtomicRmwXor16u(_) => write!(f, "i64.atomic.rmw16_u.xor"),
+			I64AtomicRmwXor32u(_) => write!(f, "i64.atomic.rmw32_u.xor"),
+
+			I32AtomicRmwXchg(_) => write!(f, "i32.atomic.rmw.xchg"),
+			I64AtomicRmwXchg(_) => write!(f, "i64.atomic.rmw.xchg"),
+			I32AtomicRmwXchg8u(_) => write!(f, "i32.atomic.rmw8_u.xchg"),
+			I32AtomicRmwXchg16u(_) => write!(f, "i32.atomic.rmw16_u.xchg"),
+			I64AtomicRmwXchg8u(_) => write!(f, "i64.atomic.rmw8_u.xchg"),
+			I64AtomicRmwXchg16u(_) => write!(f, "i64.atomic.rmw16_u.xchg"),
+			I64AtomicRmwXchg32u(_) => write!(f, "i64.atomic.rmw32_u.xchg"),
+
+			I32AtomicRmwCmpxchg(_) => write!(f, "i32.atomic.rmw.cmpxchg"),
+			I64AtomicRmwCmpxchg(_) => write!(f, "i64.atomic.rmw.cmpxchg"),
+			I32AtomicRmwCmpxchg8u(_) => write!(f, "i32.atomic.rmw8_u.cmpxchg"),
+			I32AtomicRmwCmpxchg16u(_) => write!(f, "i32.atomic.rmw16_u.cmpxchg"),
+			I64AtomicRmwCmpxchg8u(_) => write!(f, "i64.atomic.rmw8_u.cmpxchg"),
+			I64AtomicRmwCmpxchg16u(_) => write!(f, "i64.atomic.rmw16_u.cmpxchg"),
+			I64AtomicRmwCmpxchg32u(_) => write!(f, "i64.atomic.rmw32_u.cmpxchg"),
+		}
+	}
+}
+
+#[cfg(feature="simd")]
+impl fmt::Display for SimdInstruction {
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+		use self::SimdInstruction::*;
+
+		match *self {
 			V128Const(_) => write!(f, "v128.const"),
 			V128Load(_) => write!(f, "v128.load"),
 			V128Store(_) => write!(f, "v128.store"),
@@ -2663,98 +2793,6 @@ impl fmt::Display for Instruction {
 			I32x4TruncUF32x4Sat => write!(f, "i32x4.trunc_u/f32x4:sat"),
 			I64x2TruncSF64x2Sat => write!(f, "i64x2.trunc_s/f64x2:sat"),
 			I64x2TruncUF64x2Sat => write!(f, "i64x2.trunc_u/f64x2:sat"),
-
-			MemoryInit(_) => write!(f, "memory.init"),
-			MemoryDrop(_) => write!(f, "memory.drop"),
-			MemoryFill => write!(f, "memory.fill"),
-			MemoryCopy => write!(f, "memory.copy"),
-			TableInit(_) => write!(f, "table.init"),
-			TableDrop(_) => write!(f, "table.drop"),
-			TableCopy => write!(f, "table.copy"),
-		}
-	}
-}
-
-#[cfg(feature="atomics")]
-impl fmt::Display for AtomicsInstruction {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		use self::AtomicsInstruction::*;
-
-		match *self {
-			AtomicWake(_) => write!(f, "atomic.wake"),
-			I32AtomicWait(_) => write!(f, "i32.atomic.wait"),
-			I64AtomicWait(_) => write!(f, "i64.atomic.wait"),
-
-			I32AtomicLoad(_) => write!(f, "i32.atomic.load"),
-			I64AtomicLoad(_) => write!(f, "i64.atomic.load"),
-			I32AtomicLoad8u(_) => write!(f, "i32.atomic.load8_u"),
-			I32AtomicLoad16u(_) => write!(f, "i32.atomic.load16_u"),
-			I64AtomicLoad8u(_) => write!(f, "i64.atomic.load8_u"),
-			I64AtomicLoad16u(_) => write!(f, "i64.atomic.load16_u"),
-			I64AtomicLoad32u(_) => write!(f, "i64.atomic.load32_u"),
-			I32AtomicStore(_) => write!(f, "i32.atomic.store"),
-			I64AtomicStore(_) => write!(f, "i64.atomic.store"),
-			I32AtomicStore8u(_) => write!(f, "i32.atomic.store8_u"),
-			I32AtomicStore16u(_) => write!(f, "i32.atomic.store16_u"),
-			I64AtomicStore8u(_) => write!(f, "i64.atomic.store8_u"),
-			I64AtomicStore16u(_) => write!(f, "i64.atomic.store16_u"),
-			I64AtomicStore32u(_) => write!(f, "i64.atomic.store32_u"),
-
-			I32AtomicRmwAdd(_) => write!(f, "i32.atomic.rmw.add"),
-			I64AtomicRmwAdd(_) => write!(f, "i64.atomic.rmw.add"),
-			I32AtomicRmwAdd8u(_) => write!(f, "i32.atomic.rmw8_u.add"),
-			I32AtomicRmwAdd16u(_) => write!(f, "i32.atomic.rmw16_u.add"),
-			I64AtomicRmwAdd8u(_) => write!(f, "i64.atomic.rmw8_u.add"),
-			I64AtomicRmwAdd16u(_) => write!(f, "i64.atomic.rmw16_u.add"),
-			I64AtomicRmwAdd32u(_) => write!(f, "i64.atomic.rmw32_u.add"),
-
-			I32AtomicRmwSub(_) => write!(f, "i32.atomic.rmw.sub"),
-			I64AtomicRmwSub(_) => write!(f, "i64.atomic.rmw.sub"),
-			I32AtomicRmwSub8u(_) => write!(f, "i32.atomic.rmw8_u.sub"),
-			I32AtomicRmwSub16u(_) => write!(f, "i32.atomic.rmw16_u.sub"),
-			I64AtomicRmwSub8u(_) => write!(f, "i64.atomic.rmw8_u.sub"),
-			I64AtomicRmwSub16u(_) => write!(f, "i64.atomic.rmw16_u.sub"),
-			I64AtomicRmwSub32u(_) => write!(f, "i64.atomic.rmw32_u.sub"),
-
-			I32AtomicRmwAnd(_) => write!(f, "i32.atomic.rmw.and"),
-			I64AtomicRmwAnd(_) => write!(f, "i64.atomic.rmw.and"),
-			I32AtomicRmwAnd8u(_) => write!(f, "i32.atomic.rmw8_u.and"),
-			I32AtomicRmwAnd16u(_) => write!(f, "i32.atomic.rmw16_u.and"),
-			I64AtomicRmwAnd8u(_) => write!(f, "i64.atomic.rmw8_u.and"),
-			I64AtomicRmwAnd16u(_) => write!(f, "i64.atomic.rmw16_u.and"),
-			I64AtomicRmwAnd32u(_) => write!(f, "i64.atomic.rmw32_u.and"),
-
-			I32AtomicRmwOr(_) => write!(f, "i32.atomic.rmw.or"),
-			I64AtomicRmwOr(_) => write!(f, "i64.atomic.rmw.or"),
-			I32AtomicRmwOr8u(_) => write!(f, "i32.atomic.rmw8_u.or"),
-			I32AtomicRmwOr16u(_) => write!(f, "i32.atomic.rmw16_u.or"),
-			I64AtomicRmwOr8u(_) => write!(f, "i64.atomic.rmw8_u.or"),
-			I64AtomicRmwOr16u(_) => write!(f, "i64.atomic.rmw16_u.or"),
-			I64AtomicRmwOr32u(_) => write!(f, "i64.atomic.rmw32_u.or"),
-
-			I32AtomicRmwXor(_) => write!(f, "i32.atomic.rmw.xor"),
-			I64AtomicRmwXor(_) => write!(f, "i64.atomic.rmw.xor"),
-			I32AtomicRmwXor8u(_) => write!(f, "i32.atomic.rmw8_u.xor"),
-			I32AtomicRmwXor16u(_) => write!(f, "i32.atomic.rmw16_u.xor"),
-			I64AtomicRmwXor8u(_) => write!(f, "i64.atomic.rmw8_u.xor"),
-			I64AtomicRmwXor16u(_) => write!(f, "i64.atomic.rmw16_u.xor"),
-			I64AtomicRmwXor32u(_) => write!(f, "i64.atomic.rmw32_u.xor"),
-
-			I32AtomicRmwXchg(_) => write!(f, "i32.atomic.rmw.xchg"),
-			I64AtomicRmwXchg(_) => write!(f, "i64.atomic.rmw.xchg"),
-			I32AtomicRmwXchg8u(_) => write!(f, "i32.atomic.rmw8_u.xchg"),
-			I32AtomicRmwXchg16u(_) => write!(f, "i32.atomic.rmw16_u.xchg"),
-			I64AtomicRmwXchg8u(_) => write!(f, "i64.atomic.rmw8_u.xchg"),
-			I64AtomicRmwXchg16u(_) => write!(f, "i64.atomic.rmw16_u.xchg"),
-			I64AtomicRmwXchg32u(_) => write!(f, "i64.atomic.rmw32_u.xchg"),
-
-			I32AtomicRmwCmpxchg(_) => write!(f, "i32.atomic.rmw.cmpxchg"),
-			I64AtomicRmwCmpxchg(_) => write!(f, "i64.atomic.rmw.cmpxchg"),
-			I32AtomicRmwCmpxchg8u(_) => write!(f, "i32.atomic.rmw8_u.cmpxchg"),
-			I32AtomicRmwCmpxchg16u(_) => write!(f, "i32.atomic.rmw16_u.cmpxchg"),
-			I64AtomicRmwCmpxchg8u(_) => write!(f, "i64.atomic.rmw8_u.cmpxchg"),
-			I64AtomicRmwCmpxchg16u(_) => write!(f, "i64.atomic.rmw16_u.cmpxchg"),
-			I64AtomicRmwCmpxchg32u(_) => write!(f, "i64.atomic.rmw32_u.cmpxchg"),
 		}
 	}
 }

--- a/src/elements/section.rs
+++ b/src/elements/section.rs
@@ -1055,7 +1055,7 @@ mod tests {
 	#[test]
 	fn data_section_ser() {
 		let data_section = DataSection::with_entries(
-			vec![DataSegment::new(0u32, Some(InitExpr::empty()), vec![0u8; 16], false)]
+			vec![DataSegment::new(0u32, Some(InitExpr::empty()), vec![0u8; 16])]
 		);
 
 		let buf = serialize(data_section).expect("Data section to be serialized");
@@ -1089,7 +1089,7 @@ mod tests {
 	#[test]
 	fn element_section_ser() {
 		let element_section = ElementSection::with_entries(
-			vec![ElementSegment::new(0u32, Some(InitExpr::empty()), vec![0u32; 4], false)]
+			vec![ElementSegment::new(0u32, Some(InitExpr::empty()), vec![0u32; 4])]
 		);
 
 		let buf = serialize(element_section).expect("Element section to be serialized");

--- a/src/elements/types.rs
+++ b/src/elements/types.rs
@@ -41,6 +41,7 @@ pub enum ValueType {
 	F32,
 	/// 64-bit float
 	F64,
+	#[cfg(feature="simd")]
 	/// 128-bit SIMD register
 	V128,
 }
@@ -56,6 +57,7 @@ impl Deserialize for ValueType {
 			-0x02 => Ok(ValueType::I64),
 			-0x03 => Ok(ValueType::F32),
 			-0x04 => Ok(ValueType::F64),
+			#[cfg(feature="simd")]
 			-0x05 => Ok(ValueType::V128),
 			_ => Err(Error::UnknownValueType(val.into())),
 		}
@@ -71,6 +73,7 @@ impl Serialize for ValueType {
 			ValueType::I64 => -0x02,
 			ValueType::F32 => -0x03,
 			ValueType::F64 => -0x04,
+			#[cfg(feature="simd")]
 			ValueType::V128 => -0x05,
 		}.into();
 		val.serialize(writer)?;
@@ -85,6 +88,7 @@ impl fmt::Display for ValueType {
 			ValueType::I64 => write!(f, "i64"),
 			ValueType::F32 => write!(f, "f32"),
 			ValueType::F64 => write!(f, "f64"),
+			#[cfg(feature="simd")]
 			ValueType::V128 => write!(f, "v128"),
 		}
 	}
@@ -110,6 +114,7 @@ impl Deserialize for BlockType {
 			-0x02 => Ok(BlockType::Value(ValueType::I64)),
 			-0x03 => Ok(BlockType::Value(ValueType::F32)),
 			-0x04 => Ok(BlockType::Value(ValueType::F64)),
+			#[cfg(feature="simd")]
 			0x7b => Ok(BlockType::Value(ValueType::V128)),
 			-0x40 => Ok(BlockType::NoResult),
 			_ => Err(Error::UnknownValueType(val.into())),
@@ -127,6 +132,7 @@ impl Serialize for BlockType {
 			BlockType::Value(ValueType::I64) => -0x02,
 			BlockType::Value(ValueType::F32) => -0x03,
 			BlockType::Value(ValueType::F64) => -0x04,
+			#[cfg(feature="simd")]
 			BlockType::Value(ValueType::V128) => 0x7b,
 		}.into();
 		val.serialize(writer)?;


### PR DESCRIPTION
This PR is expected to return parity-wasm to be only compatible with MVP features (modulo, mutable-globals, since it doesn't change the binary format).

Here is the list of PRs that had something to do with changes, please check that this PR correctly featurizes them.

1. #223
2. #225
3. #226
4. #227
5. #243
6. #244
7. #245
8. #264

Closes #265 