### PR TITLE
Introduce Module::{from_slice, to_vec}

### DIFF
--- a/src/elements/module.rs
+++ b/src/elements/module.rs
@@ -52,8 +52,8 @@ impl Module {
 	}
 
 	/// Construct a module from a slice.
-	pub fn from_slice(input: &[u8]) -> Result<Self, Error> {
-		Ok(deserialize_buffer::<Module>(&input)?)
+	pub fn from_slice<T: AsRef<[u8]>>(input: T) -> Result<Self, Error> {
+		Ok(deserialize_buffer::<Module>(input.as_ref())?)
 	}
 
 	/// Serialize a module to a vector.

--- a/src/elements/module.rs
+++ b/src/elements/module.rs
@@ -1,7 +1,7 @@
 use crate::rust::{vec::Vec, borrow::ToOwned, string::String, cmp};
 use crate::io;
 
-use super::{Deserialize, Serialize, Error, Uint32, External};
+use super::{deserialize_buffer, serialize, Deserialize, Serialize, Error, Uint32, External};
 use super::section::{
 	Section, CodeSection, TypeSection, ImportSection, ExportSection, FunctionSection,
 	GlobalSection, TableSection, ElementSection, DataSection, MemorySection,
@@ -49,6 +49,16 @@ impl Module {
 		Module {
 			sections: sections, ..Default::default()
 		}
+	}
+
+	/// Construct a module from a slice.
+	pub fn from_slice(input: &[u8]) -> Result<Self, Error> {
+		Ok(deserialize_buffer::<Module>(&input)?)
+	}
+
+	/// Serialize a module to a vector.
+	pub fn to_vec(self) -> Result<Vec<u8>, Error> {
+		Ok(serialize::<Module>(self)?)
 	}
 
 	/// Destructure the module, yielding sections
@@ -947,5 +957,13 @@ mod integration_tests {
         // Try serialisation roundtrip to check well-orderedness.
         let serialized = serialize(module).expect("serialization to succeed");
         assert!(deserialize_buffer::<Module>(&serialized).is_ok());
+    }
+
+    #[test]
+    fn serialization_roundtrip() {
+        let module = deserialize_file("./res/cases/v1/test.wasm").expect("failed to deserialize");
+        let module_copy = module.clone().to_vec().expect("failed to serialize");
+        let module_copy = Module::from_slice(&module_copy).expect("failed to deserialize");
+        assert_eq!(module, module_copy);
     }
 }

--- a/src/elements/module.rs
+++ b/src/elements/module.rs
@@ -52,12 +52,12 @@ impl Module {
 	}
 
 	/// Construct a module from a slice.
-	pub fn from_slice<T: AsRef<[u8]>>(input: T) -> Result<Self, Error> {
+	pub fn from_bytes<T: AsRef<[u8]>>(input: T) -> Result<Self, Error> {
 		Ok(deserialize_buffer::<Module>(input.as_ref())?)
 	}
 
 	/// Serialize a module to a vector.
-	pub fn to_vec(self) -> Result<Vec<u8>, Error> {
+	pub fn to_bytes(self) -> Result<Vec<u8>, Error> {
 		Ok(serialize::<Module>(self)?)
 	}
 
@@ -962,8 +962,8 @@ mod integration_tests {
     #[test]
     fn serialization_roundtrip() {
         let module = deserialize_file("./res/cases/v1/test.wasm").expect("failed to deserialize");
-        let module_copy = module.clone().to_vec().expect("failed to serialize");
-        let module_copy = Module::from_slice(&module_copy).expect("failed to deserialize");
+        let module_copy = module.clone().to_bytes().expect("failed to serialize");
+        let module_copy = Module::from_bytes(&module_copy).expect("failed to deserialize");
         assert_eq!(module, module_copy);
     }
 }


### PR DESCRIPTION
This is a common use case and simplifies the usability of the library.