### PR TITLE
Reduce stack allocated buffered size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,11 @@ time = "0.1"
 default = ["std"]
 std = []
 
+# Reduce stack usage for buffered read operations.
+# This feature is useful when integrating on resource constrained devices such as microcontroler
+# where the stack size is fixed (stacks do not grow) and limited to a few (k)bytes.
+reduced-stack-buffer = []
+
 #
 # Features for enabling non-MVP proposals.
 # These features should be tested as part of Travis CI build.

--- a/src/elements/section.rs
+++ b/src/elements/section.rs
@@ -26,6 +26,10 @@ use super::types::Type;
 use super::name_section::NameSection;
 use super::reloc_section::RelocSection;
 
+#[cfg(feature = "reduced-stack-buffer")]
+const ENTRIES_BUFFER_LENGTH: usize = 256;
+
+#[cfg(not(feature = "reduced-stack-buffer"))]
 const ENTRIES_BUFFER_LENGTH: usize = 16384;
 
 /// Section in the WebAssembly module.
@@ -331,7 +335,7 @@ impl Deserialize for CustomSection {
 
 	fn deserialize<R: io::Read>(reader: &mut R) -> Result<Self, Self::Error> {
 		let section_length: usize = u32::from(VarUint32::deserialize(reader)?) as usize;
-		let buf = buffered_read!(16384, section_length, reader);
+		let buf = buffered_read!(ENTRIES_BUFFER_LENGTH, section_length, reader);
 		let mut cursor = io::Cursor::new(&buf[..]);
 		let name = String::deserialize(&mut cursor)?;
 		let payload = buf[cursor.position() as usize..].to_vec();

--- a/src/elements/segment.rs
+++ b/src/elements/segment.rs
@@ -9,6 +9,12 @@ const FLAG_PASSIVE: u32 = 1;
 #[cfg(feature="bulk")]
 const FLAG_MEM_NONZERO: u32 = 2;
 
+#[cfg(feature = "reduced-stack-buffer")]
+const VALUES_BUFFER_LENGTH: usize = 256;
+
+#[cfg(not(feature = "reduced-stack-buffer"))]
+const VALUES_BUFFER_LENGTH: usize = 16384;
+
 /// Entry in the element section.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ElementSegment {
@@ -217,7 +223,7 @@ impl Deserialize for DataSegment {
 		let index = VarUint32::deserialize(reader)?;
 		let offset = InitExpr::deserialize(reader)?;
 		let value_len = u32::from(VarUint32::deserialize(reader)?) as usize;
-		let value_buf = buffered_read!(65536, value_len, reader);
+		let value_buf = buffered_read!(VALUES_BUFFER_LENGTH, value_len, reader);
 
 		Ok(DataSegment {
 			index: index.into(),
@@ -242,7 +248,7 @@ impl Deserialize for DataSegment {
 			Some(InitExpr::deserialize(reader)?)
 		};
 		let value_len = u32::from(VarUint32::deserialize(reader)?) as usize;
-		let value_buf = buffered_read!(65536, value_len, reader);
+		let value_buf = buffered_read!(VALUES_BUFFER_LENGTH, value_len, reader);
 
 		Ok(DataSegment {
 			index: index,


### PR DESCRIPTION
Constrained targets such as microcontroller will rarely have more than a few kilo byte of stack.