### PR TITLE
Support for no_std in stable rust.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,6 @@ in a `no_std` context, add the following to your `Cargo.toml` (still requires al
 parity-wasm = { version = "0.40", default-features = false }
 ```
 
-Until allocator api is stabilized, this type of use is limited to nightly Rust.
-
 # License
 
 `parity-wasm` is primarily distributed under the terms of both the MIT

--- a/src/builder/code.rs
+++ b/src/builder/code.rs
@@ -1,4 +1,4 @@
-use crate::rust::vec::Vec;
+use alloc::vec::Vec;
 use crate::elements;
 use super::{
 	invoke::{Invoke, Identity},

--- a/src/builder/data.rs
+++ b/src/builder/data.rs
@@ -1,4 +1,4 @@
-use crate::rust::vec::Vec;
+use alloc::vec::Vec;
 use super::invoke::{Identity, Invoke};
 use crate::elements;
 

--- a/src/builder/export.rs
+++ b/src/builder/export.rs
@@ -1,4 +1,4 @@
-use crate::rust::{string::String, borrow::ToOwned};
+use alloc::{borrow::ToOwned, string::String};
 use super::invoke::{Invoke, Identity};
 use crate::elements;
 

--- a/src/builder/import.rs
+++ b/src/builder/import.rs
@@ -1,4 +1,4 @@
-use crate::rust::{borrow::ToOwned, string::String};
+use alloc::{borrow::ToOwned, string::String};
 use super::invoke::{Identity, Invoke};
 use crate::elements;
 

--- a/src/builder/memory.rs
+++ b/src/builder/memory.rs
@@ -1,4 +1,4 @@
-use crate::rust::vec::Vec;
+use alloc::vec::Vec;
 use crate::elements;
 use super::invoke::{Invoke, Identity};
 

--- a/src/builder/misc.rs
+++ b/src/builder/misc.rs
@@ -1,4 +1,4 @@
-use crate::rust::vec::Vec;
+use alloc::vec::Vec;
 use super::invoke::{Invoke, Identity};
 use crate::elements;
 

--- a/src/builder/module.rs
+++ b/src/builder/module.rs
@@ -1,4 +1,4 @@
-use crate::rust::vec::Vec;
+use alloc::vec::Vec;
 use crate::elements;
 use super::{
 	import,

--- a/src/builder/table.rs
+++ b/src/builder/table.rs
@@ -1,4 +1,4 @@
-use crate::rust::vec::Vec;
+use alloc::vec::Vec;
 use crate::elements;
 use super::invoke::{Invoke, Identity};
 

--- a/src/elements/export_entry.rs
+++ b/src/elements/export_entry.rs
@@ -1,4 +1,4 @@
-use crate::rust::string::String;
+use alloc::string::String;
 use super::{Deserialize, Serialize, Error, VarUint7, VarUint32};
 use crate::io;
 

--- a/src/elements/func.rs
+++ b/src/elements/func.rs
@@ -1,4 +1,4 @@
-use crate::rust::vec::Vec;
+use alloc::vec::Vec;
 use super::{
 	Deserialize, Error, ValueType, VarUint32, CountedList, Instructions,
 	Serialize, CountedWriter, CountedListWriter,

--- a/src/elements/import_entry.rs
+++ b/src/elements/import_entry.rs
@@ -1,4 +1,4 @@
-use crate::rust::string::String;
+use alloc::string::String;
 use crate::io;
 use super::{
 	Deserialize, Serialize, Error, VarUint7, VarInt7, VarUint32, VarUint1, Uint8,

--- a/src/elements/index_map.rs
+++ b/src/elements/index_map.rs
@@ -1,14 +1,14 @@
-use crate::rust::{
-	cmp::min,
-	iter::{FromIterator, IntoIterator},
-	mem,
-	slice,
-	vec::{self, Vec},
-};
-
+use alloc::vec::Vec;
 use crate::io;
 
 use super::{Deserialize, Error, Serialize, VarUint32};
+
+use alloc::vec;
+use core::{
+	cmp::min,
+	iter::{FromIterator, IntoIterator},
+	mem, slice
+};
 
 /// A map from non-contiguous `u32` keys to values of type `T`, which is
 /// serialized and deserialized ascending order of the keys. Normally used for

--- a/src/elements/mod.rs
+++ b/src/elements/mod.rs
@@ -1,7 +1,9 @@
 //! Elements of the WebAssembly binary format.
 
-use crate::rust::{fmt, vec::Vec, format, string::String};
+use alloc::{string::String, vec::Vec};
 use crate::io;
+
+use core::fmt;
 
 macro_rules! buffered_read {
 	($buffer_size: expr, $length: expr, $reader: expr) => {

--- a/src/elements/module.rs
+++ b/src/elements/module.rs
@@ -1,4 +1,4 @@
-use crate::rust::{vec::Vec, borrow::ToOwned, string::String, cmp};
+use alloc::{borrow::ToOwned, vec::Vec, string::String};
 use crate::io;
 
 use super::{deserialize_buffer, serialize, Deserialize, Serialize, Error, Uint32, External};
@@ -9,6 +9,8 @@ use super::section::{
 };
 use super::name_section::NameSection;
 use super::reloc_section::RelocSection;
+
+use core::cmp;
 
 const WASM_MAGIC_NUMBER: [u8; 4] = [0x00, 0x61, 0x73, 0x6d];
 

--- a/src/elements/name_section.rs
+++ b/src/elements/name_section.rs
@@ -1,4 +1,4 @@
-use crate::rust::{vec::Vec, string::String};
+use alloc::{string::String, vec::Vec};
 use crate::io;
 
 use super::{Deserialize, Error, Module, Serialize, VarUint32, VarUint7, Type};

--- a/src/elements/ops.rs
+++ b/src/elements/ops.rs
@@ -1,4 +1,4 @@
-use crate::rust::{fmt, vec::Vec, boxed::Box};
+use alloc::{boxed::Box, vec::Vec};
 use crate::io;
 use super::{
 	Serialize, Deserialize, Error,
@@ -6,6 +6,7 @@ use super::{
 	Uint32, Uint64, CountedListWriter,
 	VarInt32, VarInt64,
 };
+use core::fmt;
 
 /// List of instructions (usually inside a block section).
 #[derive(Debug, Clone, PartialEq)]

--- a/src/elements/primitives.rs
+++ b/src/elements/primitives.rs
@@ -1,4 +1,4 @@
-use crate::rust::{vec::Vec, string::String};
+use alloc::{string::String, vec::Vec};
 use crate::{io, elements};
 use super::{Error, Deserialize, Serialize};
 

--- a/src/elements/reloc_section.rs
+++ b/src/elements/reloc_section.rs
@@ -1,4 +1,4 @@
-use crate::rust::{vec::Vec, string::String};
+use alloc::{string::String, vec::Vec};
 use crate::io;
 
 use super::{CountedList, CountedListWriter, CountedWriter, Deserialize, Error, Serialize, VarInt32, VarUint32, VarUint7};

--- a/src/elements/section.rs
+++ b/src/elements/section.rs
@@ -1,4 +1,4 @@
-use crate::rust::{vec::Vec, string::String, borrow::ToOwned};
+use alloc::{vec::Vec, borrow::ToOwned, string::String};
 use crate::{io, elements};
 use super::{
 	Serialize,

--- a/src/elements/segment.rs
+++ b/src/elements/segment.rs
@@ -1,4 +1,4 @@
-use crate::rust::vec::Vec;
+use alloc::vec::Vec;
 use crate::io;
 use super::{Deserialize, Serialize, Error, VarUint32, CountedList, InitExpr, CountedListWriter};
 

--- a/src/elements/types.rs
+++ b/src/elements/types.rs
@@ -1,9 +1,10 @@
-use crate::rust::{fmt, vec::Vec};
+use alloc::vec::Vec;
 use crate::io;
 use super::{
 	Deserialize, Serialize, Error, VarUint7, VarInt7, VarUint1, CountedList,
 	CountedListWriter, VarUint32,
 };
+use core::fmt;
 
 /// Type definition in types section. Currently can be only of the function type.
 #[derive(Debug, Clone, PartialEq, Hash, Eq)]

--- a/src/io.rs
+++ b/src/io.rs
@@ -3,13 +3,8 @@
 //! Basically it just a replacement for the std::io that is usable from
 //! the `no_std` environment.
 
-use crate::rust::result;
-
 #[cfg(feature="std")]
-use crate::rust::io;
-
-#[cfg(not(feature="std"))]
-use crate::rust::vec::Vec;
+use std::io;
 
 /// IO specific error.
 #[derive(Debug)]
@@ -24,11 +19,11 @@ pub enum Error {
 	InvalidData,
 
 	#[cfg(feature = "std")]
-	IoError(io::Error),
+	IoError(std::io::Error),
 }
 
 /// IO specific Result.
-pub type Result<T> = result::Result<T, Error>;
+pub type Result<T> = core::result::Result<T, Error>;
 
 pub trait Write {
 	/// Write a buffer of data into this write.
@@ -78,7 +73,7 @@ impl<T: AsRef<[u8]>> Read for Cursor<T> {
 }
 
 #[cfg(not(feature = "std"))]
-impl Write for Vec<u8> {
+impl Write for alloc::vec::Vec<u8> {
 	fn write(&mut self, buf: &[u8]) -> Result<()> {
 		self.extend(buf);
 		Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,9 +2,8 @@
 #![warn(missing_docs)]
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(not(feature = "std"), feature(alloc))]
 
-#[cfg(not(feature="std"))] #[macro_use]
+#[macro_use]
 extern crate alloc;
 
 pub mod elements;
@@ -23,18 +22,3 @@ pub use elements::{
 	deserialize_file,
 	serialize_to_file,
 };
-
-#[cfg(not(feature = "std"))]
-pub (crate) mod rust {
-	pub use core::*;
-	pub use ::alloc::format;
-	pub use ::alloc::vec;
-	pub use ::alloc::string;
-	pub use ::alloc::boxed;
-	pub use ::alloc::borrow;
-}
-
-#[cfg(feature="std")]
-pub (crate) mod rust {
-	pub use std::*;
-}


### PR DESCRIPTION
The alloc crate is crate is now stable so we can support no_std without the feature flag: `#[feature(alloc)] `.

This pr makes the `parity-wasm` crate buildable using no_std in stable rust.

Changes:
- remove the #[feature(alloc)] and replace it with `extern crate alloc;`
- The internal module named "rust" was a shim for std. Since core and alloc
  are available in no_std, the shim is no longer needed. The "rust" module
  is removed by this pr.
- remove the clause in the readme requiring rust nightly for no_std builds