### PR TITLE
Improve parser for name section

### DIFF
--- a/src/elements/name_section.rs
+++ b/src/elements/name_section.rs
@@ -263,7 +263,17 @@ impl LocalNameSubsection {
 
 		let max_locals = module
 			.code_section()
-			.map(|cs| cs.bodies().iter().map(|f| f.locals().len()).max().unwrap_or(0))
+			.map(|cs|
+                cs.bodies()
+                    .iter()
+                    .map(|f|
+                        f.locals()
+                            .iter()
+                            .map(|l| l.count() as usize)
+                           .max()
+                          .unwrap_or(0))
+                    .max()
+                    .unwrap_or(0))
 			.unwrap_or(0);
 
 		let max_space = max_signature_args + max_locals;

--- a/src/elements/name_section.rs
+++ b/src/elements/name_section.rs
@@ -270,8 +270,7 @@ impl LocalNameSubsection {
 						f.locals()
 						   .iter()
 						   .map(|l| l.count() as usize)
-						   .max()
-						   .unwrap_or(0))
+						   .sum())
 					.max()
 					.unwrap_or(0))
 			.unwrap_or(0);

--- a/src/elements/name_section.rs
+++ b/src/elements/name_section.rs
@@ -264,16 +264,16 @@ impl LocalNameSubsection {
 		let max_locals = module
 			.code_section()
 			.map(|cs|
-                cs.bodies()
-                    .iter()
-                    .map(|f|
-                        f.locals()
-                            .iter()
-                            .map(|l| l.count() as usize)
-                           .max()
-                          .unwrap_or(0))
-                    .max()
-                    .unwrap_or(0))
+				cs.bodies()
+					.iter()
+					.map(|f|
+						f.locals()
+						   .iter()
+						   .map(|l| l.count() as usize)
+						   .max()
+						   .unwrap_or(0))
+					.max()
+					.unwrap_or(0))
 			.unwrap_or(0);
 
 		let max_space = max_signature_args + max_locals;


### PR DESCRIPTION
the calculation of the largest possible index of locals was not taking
compressed locals (`count > 1`) into account.

Related to https://github.com/paritytech/parity-wasm/issues/271