### PR TITLE
Support converting custom sections from module into module scaffold

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parity-wasm"
-version = "0.42.1"
+version = "0.41.0"
 authors = ["Nikolay Volf <nikvolf@gmail.com>", "Svyatoslav Nikolsky <svyatonik@yandex.ru>", "Sergey Shulepov <s.pepyakin@gmail.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parity-wasm"
-version = "0.41.0"
+version = "0.42.1"
 authors = ["Nikolay Volf <nikvolf@gmail.com>", "Svyatoslav Nikolsky <svyatonik@yandex.ru>", "Sergey Shulepov <s.pepyakin@gmail.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/src/builder/module.rs
+++ b/src/builder/module.rs
@@ -55,7 +55,7 @@ impl From<elements::Module> for ModuleScaffold {
 		let mut code: Option<elements::CodeSection> = None;
 		let mut data: Option<elements::DataSection> = None;
 
-        let mut other = Vec::new();
+		let mut other = Vec::new();
 		let mut sections = module.into_sections();
 		while let Some(section) = sections.pop() {
 			match section {

--- a/src/builder/module.rs
+++ b/src/builder/module.rs
@@ -55,6 +55,7 @@ impl From<elements::Module> for ModuleScaffold {
 		let mut code: Option<elements::CodeSection> = None;
 		let mut data: Option<elements::DataSection> = None;
 
+        let mut other = Vec::new();
 		let mut sections = module.into_sections();
 		while let Some(section) = sections.pop() {
 			match section {
@@ -69,7 +70,7 @@ impl From<elements::Module> for ModuleScaffold {
 				elements::Section::Element(sect) => { element = Some(sect); }
 				elements::Section::Code(sect) => { code = Some(sect); }
 				elements::Section::Data(sect) => { data = Some(sect); }
-				_ => {}
+				section => other.push(section)
 			}
 		}
 
@@ -85,7 +86,7 @@ impl From<elements::Module> for ModuleScaffold {
 			element: element.unwrap_or_default(),
 			code: code.unwrap_or_default(),
 			data: data.unwrap_or_default(),
-			other: sections,
+			other,
 		}
 	}
 }


### PR DESCRIPTION
## Desc

The usage of `pop` in https://github.com/paritytech/parity-wasm/blob/5b56959a1ef3b7841352fd59a5cfb1c474dc1ff0/src/builder/module.rs#L59

drops custom sections.

Work for the name section, related to #298, #271.