### PR TITLE
Fix form initialization in FunctionType::new.

### DIFF
--- a/src/elements/types.rs
+++ b/src/elements/types.rs
@@ -163,7 +163,7 @@ impl FunctionType {
 	/// New function type given the params and results as vectors
 	pub fn new(params: Vec<ValueType>, results: Vec<ValueType>) -> Self {
 		FunctionType {
-			form: 0,
+			form: 0x60,
 			params,
 			results,
 		}


### PR DESCRIPTION
The `form` field was incorrectly initialized to 0, while the only valid value is 0x60.