### PR TITLE
Cleanup / Compat. breaking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parity-wasm"
-version = "0.42.2"
+version = "0.43.0"
 authors = ["Nikolay Volf <nikvolf@gmail.com>", "Svyatoslav Nikolsky <svyatonik@yandex.ru>", "Sergey Shulepov <s.pepyakin@gmail.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/src/io.rs
+++ b/src/io.rs
@@ -19,7 +19,7 @@ pub enum Error {
 	InvalidData,
 
 	#[cfg(feature = "std")]
-	IoError(std::io::Error),
+	Io(std::io::Error),
 }
 
 /// IO specific Result.
@@ -84,14 +84,14 @@ impl Write for alloc::vec::Vec<u8> {
 impl<T: io::Read> Read for T {
 	fn read(&mut self, buf: &mut [u8]) -> Result<()> {
 		self.read_exact(buf)
-			.map_err(Error::IoError)
+			.map_err(Error::Io)
 	}
 }
 
 #[cfg(feature = "std")]
 impl<T: io::Write> Write for T {
 	fn write(&mut self, buf: &[u8]) -> Result<()> {
-		self.write_all(buf).map_err(Error::IoError)
+		self.write_all(buf).map_err(Error::Io)
 	}
 }
 


### PR DESCRIPTION
This very simple PR is following #305.
Clippy checks fail as other PRs are required to fix all issues, see also:
- #305
- #307

It comes separate as it introduces a small but nonetheless breaking change.