### PR TITLE
Update dev dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude = [ "res/*", "spec/*" ]
 edition = "2018"
 
 [dev-dependencies]
-time = "0.1"
+time = "0.2"
 
 [features]
 default = ["std"]


### PR DESCRIPTION
`time` is used in the benchmarks.