### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# For details about syntax, see:
+# https://help.github.com/en/articles/about-code-owners
+
+/ @NikVolf @pepyakin


### PR DESCRIPTION
I set the main contributors as CODEOWNERS of the whole repository. See paritytech/ci_cd#169