### PR TITLE
base public api on slices, not vectors

### DIFF
--- a/src/builder/code.rs
+++ b/src/builder/code.rs
@@ -45,8 +45,11 @@ where
 	}
 
 	/// Add multiple arguments to signature builder
-	pub fn with_params(mut self, value_types: &[elements::ValueType]) -> Self {
-		self.signature.params_mut().extend(value_types.iter().copied());
+	pub fn with_params<I>(mut self, value_types: I) -> Self
+	where
+		I: IntoIterator<Item = elements::ValueType>,
+	{
+		self.signature.params_mut().extend(value_types);
 		self
 	}
 
@@ -67,8 +70,11 @@ where
 	}
 
 	/// Add multiple results to signature builder
-	pub fn with_results(mut self, value_types: &[elements::ValueType]) -> Self {
-		self.signature.results_mut().extend(value_types.iter().copied());
+	pub fn with_results<I>(mut self, value_types: I) -> Self
+	where
+		I: IntoIterator<Item = elements::ValueType>,
+	{
+		self.signature.results_mut().extend(value_types);
 		self
 	}
 
@@ -93,24 +99,14 @@ where
 	}
 }
 
-impl<F> Invoke<Vec<elements::ValueType>> for SignatureBuilder<F>
+impl<F, I> Invoke<I> for SignatureBuilder<F>
 where
 	F: Invoke<elements::FunctionType>,
+	I: IntoIterator<Item = elements::ValueType>,
 {
 	type Result = Self;
 
-	fn invoke(self, args: Vec<elements::ValueType>) -> Self {
-		self.with_params(args.as_slice())
-	}
-}
-
-impl<F> Invoke<&[elements::ValueType]> for SignatureBuilder<F>
-where
-	F: Invoke<elements::FunctionType>,
-{
-	type Result = Self;
-
-	fn invoke(self, args: &[elements::ValueType]) -> Self {
+	fn invoke(self, args: I) -> Self {
 		self.with_params(args)
 	}
 }
@@ -274,8 +270,11 @@ where
 	}
 
 	/// Extend function local list with new entries
-	pub fn with_locals(mut self, locals: &[elements::Local]) -> Self {
-		self.body.locals_mut().extend(locals.iter().copied());
+	pub fn with_locals<I>(mut self, locals: I) -> Self
+	where
+		I: IntoIterator<Item = elements::Local>,
+	{
+		self.body.locals_mut().extend(locals);
 		self
 	}
 

--- a/src/builder/code.rs
+++ b/src/builder/code.rs
@@ -45,8 +45,8 @@ where
 	}
 
 	/// Add multiple arguments to signature builder
-	pub fn with_params(mut self, value_types: Vec<elements::ValueType>) -> Self {
-		self.signature.params_mut().extend(value_types);
+	pub fn with_params(mut self, value_types: &[elements::ValueType]) -> Self {
+		self.signature.params_mut().extend(value_types.iter().copied());
 		self
 	}
 
@@ -67,8 +67,8 @@ where
 	}
 
 	/// Add multiple results to signature builder
-	pub fn with_results(mut self, value_types: Vec<elements::ValueType>) -> Self {
-		self.signature.results_mut().extend(value_types);
+	pub fn with_results(mut self, value_types: &[elements::ValueType]) -> Self {
+		self.signature.results_mut().extend(value_types.iter().copied());
 		self
 	}
 
@@ -100,6 +100,17 @@ where
 	type Result = Self;
 
 	fn invoke(self, args: Vec<elements::ValueType>) -> Self {
+		self.with_params(args.as_slice())
+	}
+}
+
+impl<F> Invoke<&[elements::ValueType]> for SignatureBuilder<F>
+where
+	F: Invoke<elements::FunctionType>,
+{
+	type Result = Self;
+
+	fn invoke(self, args: &[elements::ValueType]) -> Self {
 		self.with_params(args)
 	}
 }
@@ -263,8 +274,8 @@ where
 	}
 
 	/// Extend function local list with new entries
-	pub fn with_locals(mut self, locals: Vec<elements::Local>) -> Self {
-		self.body.locals_mut().extend(locals);
+	pub fn with_locals(mut self, locals: &[elements::Local]) -> Self {
+		self.body.locals_mut().extend(locals.iter().copied());
 		self
 	}
 


### PR DESCRIPTION
When the arguments are `Copy`, then accepting slices over vectors seems like the better approach to me

- marginally less data to pass (one word)
- allows passing other data types (in particular we use [`bumpalo`](https://docs.rs/bumpalo/3.7.0/bumpalo/) vectors and would like to use them with this crate).

These changes broke no tests, but I'd assume this is still a breaking change in some cases. 