### PR TITLE
Fix threads proposal parsing

### DIFF
--- a/src/elements/ops.rs
+++ b/src/elements/ops.rs
@@ -1434,6 +1434,14 @@ fn deserialize_atomic<R: io::Read>(reader: &mut R) -> Result<Instruction, Error>
 		I64_ATOMIC_RMW_SUB16U => I64AtomicRmwSub16u(mem),
 		I64_ATOMIC_RMW_SUB32U => I64AtomicRmwSub32u(mem),
 
+		I32_ATOMIC_RMW_AND => I32AtomicRmwAnd(mem),
+		I64_ATOMIC_RMW_AND => I64AtomicRmwAnd(mem),
+		I32_ATOMIC_RMW_AND8U => I32AtomicRmwAnd8u(mem),
+		I32_ATOMIC_RMW_AND16U => I32AtomicRmwAnd16u(mem),
+		I64_ATOMIC_RMW_AND8U => I64AtomicRmwAnd8u(mem),
+		I64_ATOMIC_RMW_AND16U => I64AtomicRmwAnd16u(mem),
+		I64_ATOMIC_RMW_AND32U => I64AtomicRmwAnd32u(mem),
+
 		I32_ATOMIC_RMW_OR => I32AtomicRmwOr(mem),
 		I64_ATOMIC_RMW_OR => I64AtomicRmwOr(mem),
 		I32_ATOMIC_RMW_OR8U => I32AtomicRmwOr8u(mem),

--- a/testsuite/src/lib.rs
+++ b/testsuite/src/lib.rs
@@ -21,3 +21,8 @@ fn basic(path: &str) {
 		run::check(path);
 	}
 }
+
+#[test_generator::test_resources("testsuite/spec/proposals/threads/*.wast")]
+fn threads(path: &str) {
+	run::check(path);
+}

--- a/testsuite/src/run.rs
+++ b/testsuite/src/run.rs
@@ -13,7 +13,7 @@ pub fn check(path: &str) {
 		match kind {
 			WastDirective::Module(mut module) => {
 				let (line, _col) = module.span.linecol_in(&source);
-				println!("Parsing module at line {}", line);
+				println!("Parsing module at line {}", line + 1);
 				let orig_bytes = module.encode().unwrap();
 				let parsed =
 					deserialize_buffer::<Module>(&orig_bytes).expect("Failed to parse module");
@@ -25,7 +25,7 @@ pub fn check(path: &str) {
 				span,
 			} => {
 				let (line, _col) = span.linecol_in(&source);
-				println!("Parsing assert_malformed at line {}", line);
+				println!("Parsing assert_malformed at line {}", line + 1);
 				let parsed = deserialize_buffer::<Module>(&module.encode().unwrap());
 				if parsed.is_ok() {
 					panic!("Module should be malformed because: {}", message);


### PR DESCRIPTION
The threads proposal parsing was incomplete which was evident when I activated the tests for them (there were none before).

This adds the missing instructions.