### PR TITLE
Add the "offsets" feature.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,14 @@ std = []
 # where the stack size is fixed (stacks do not grow) and limited to a few (k)bytes.
 reduced-stack-buffer = []
 
+
+# Provide a way to query the (absolute) offsets of the code section and individual instructions.
+# This can be useful if you want to to work with DWARF debug information, for example
+# when using the addr2line crate.
+# This is a separate feature because all deserialize functions then 
+# require something that is Read + Seek instead of only Read
+offsets = []
+
 #
 # Features for enabling non-MVP proposals.
 # These features should be tested as part of Travis CI build.

--- a/src/elements/export_entry.rs
+++ b/src/elements/export_entry.rs
@@ -18,7 +18,7 @@ pub enum Internal {
 impl Deserialize for Internal {
 	type Error = Error;
 
-	fn deserialize<R: io::Read>(reader: &mut R) -> Result<Self, Self::Error> {
+	fn deserialize<R: io::ReadSeek>(reader: &mut R) -> Result<Self, Self::Error> {
 		let kind = VarUint7::deserialize(reader)?;
 		match kind.into() {
 			0x00 => Ok(Internal::Function(VarUint32::deserialize(reader)?.into())),
@@ -85,7 +85,7 @@ impl ExportEntry {
 impl Deserialize for ExportEntry {
 	type Error = Error;
 
-	fn deserialize<R: io::Read>(reader: &mut R) -> Result<Self, Self::Error> {
+	fn deserialize<R: io::ReadSeek>(reader: &mut R) -> Result<Self, Self::Error> {
 		let field_str = String::deserialize(reader)?;
 		let internal = Internal::deserialize(reader)?;
 

--- a/src/elements/func.rs
+++ b/src/elements/func.rs
@@ -37,7 +37,7 @@ impl Serialize for Func {
 impl Deserialize for Func {
 	type Error = Error;
 
-	fn deserialize<R: io::Read>(reader: &mut R) -> Result<Self, Self::Error> {
+	fn deserialize<R: io::ReadSeek>(reader: &mut R) -> Result<Self, Self::Error> {
 		Ok(Func(VarUint32::deserialize(reader)?.into()))
 	}
 }
@@ -69,7 +69,7 @@ impl Local {
 impl Deserialize for Local {
 	type Error = Error;
 
-	fn deserialize<R: io::Read>(reader: &mut R) -> Result<Self, Self::Error> {
+	fn deserialize<R: io::ReadSeek>(reader: &mut R) -> Result<Self, Self::Error> {
 		let count = VarUint32::deserialize(reader)?;
 		let value_type = ValueType::deserialize(reader)?;
 		Ok(Local { count: count.into(), value_type })
@@ -130,7 +130,7 @@ impl FuncBody {
 impl Deserialize for FuncBody {
 	type Error = Error;
 
-	fn deserialize<R: io::Read>(reader: &mut R) -> Result<Self, Self::Error> {
+	fn deserialize<R: io::ReadSeek>(reader: &mut R) -> Result<Self, Self::Error> {
 		let mut body_reader = SectionReader::new(reader)?;
 		let locals: Vec<Local> = CountedList::<Local>::deserialize(&mut body_reader)?.into_inner();
 

--- a/src/elements/global_entry.rs
+++ b/src/elements/global_entry.rs
@@ -34,7 +34,7 @@ impl GlobalEntry {
 impl Deserialize for GlobalEntry {
 	type Error = Error;
 
-	fn deserialize<R: io::Read>(reader: &mut R) -> Result<Self, Self::Error> {
+	fn deserialize<R: io::ReadSeek>(reader: &mut R) -> Result<Self, Self::Error> {
 		let global_type = GlobalType::deserialize(reader)?;
 		let init_expr = InitExpr::deserialize(reader)?;
 

--- a/src/elements/import_entry.rs
+++ b/src/elements/import_entry.rs
@@ -36,7 +36,7 @@ impl GlobalType {
 impl Deserialize for GlobalType {
 	type Error = Error;
 
-	fn deserialize<R: io::Read>(reader: &mut R) -> Result<Self, Self::Error> {
+	fn deserialize<R: io::ReadSeek>(reader: &mut R) -> Result<Self, Self::Error> {
 		let content_type = ValueType::deserialize(reader)?;
 		let is_mutable = VarUint1::deserialize(reader)?;
 		Ok(GlobalType { content_type, is_mutable: is_mutable.into() })
@@ -80,7 +80,7 @@ impl TableType {
 impl Deserialize for TableType {
 	type Error = Error;
 
-	fn deserialize<R: io::Read>(reader: &mut R) -> Result<Self, Self::Error> {
+	fn deserialize<R: io::ReadSeek>(reader: &mut R) -> Result<Self, Self::Error> {
 		let elem_type = TableElementType::deserialize(reader)?;
 		let limits = ResizableLimits::deserialize(reader)?;
 		Ok(TableType { elem_type, limits })
@@ -134,7 +134,7 @@ impl ResizableLimits {
 impl Deserialize for ResizableLimits {
 	type Error = Error;
 
-	fn deserialize<R: io::Read>(reader: &mut R) -> Result<Self, Self::Error> {
+	fn deserialize<R: io::ReadSeek>(reader: &mut R) -> Result<Self, Self::Error> {
 		let flags: u8 = Uint8::deserialize(reader)?.into();
 		match flags {
 			// Default flags are always supported. This is simply: FLAG_HAS_MAX={true, false}.
@@ -219,7 +219,7 @@ impl MemoryType {
 impl Deserialize for MemoryType {
 	type Error = Error;
 
-	fn deserialize<R: io::Read>(reader: &mut R) -> Result<Self, Self::Error> {
+	fn deserialize<R: io::ReadSeek>(reader: &mut R) -> Result<Self, Self::Error> {
 		Ok(MemoryType(ResizableLimits::deserialize(reader)?))
 	}
 }
@@ -249,7 +249,7 @@ pub enum External {
 impl Deserialize for External {
 	type Error = Error;
 
-	fn deserialize<R: io::Read>(reader: &mut R) -> Result<Self, Self::Error> {
+	fn deserialize<R: io::ReadSeek>(reader: &mut R) -> Result<Self, Self::Error> {
 		let kind = VarUint7::deserialize(reader)?;
 		match kind.into() {
 			0x00 => Ok(External::Function(VarUint32::deserialize(reader)?.into())),
@@ -338,7 +338,7 @@ impl ImportEntry {
 impl Deserialize for ImportEntry {
 	type Error = Error;
 
-	fn deserialize<R: io::Read>(reader: &mut R) -> Result<Self, Self::Error> {
+	fn deserialize<R: io::ReadSeek>(reader: &mut R) -> Result<Self, Self::Error> {
 		let module_str = String::deserialize(reader)?;
 		let field_str = String::deserialize(reader)?;
 		let external = External::deserialize(reader)?;

--- a/src/elements/index_map.rs
+++ b/src/elements/index_map.rs
@@ -150,7 +150,7 @@ impl<T> IndexMap<T> {
 		rdr: &mut R,
 	) -> Result<IndexMap<T>, Error>
 	where
-		R: io::Read,
+		R: io::ReadSeek,
 		F: Fn(u32, &mut R) -> Result<T, Error>,
 	{
 		let len: u32 = VarUint32::deserialize(rdr)?.into();
@@ -331,7 +331,10 @@ where
 	/// Deserialize a map containing simple values that support `Deserialize`.
 	/// We will allocate an underlying array no larger than `max_entry_space` to
 	/// hold the data, so the maximum index must be less than `max_entry_space`.
-	pub fn deserialize<R: io::Read>(max_entry_space: usize, rdr: &mut R) -> Result<Self, Error> {
+	pub fn deserialize<R: io::ReadSeek>(
+		max_entry_space: usize,
+		rdr: &mut R,
+	) -> Result<Self, Error> {
 		let deserialize_value: fn(u32, &mut R) -> Result<T, Error> =
 			|_idx, rdr| T::deserialize(rdr).map_err(Error::from);
 		Self::deserialize_with(max_entry_space, &deserialize_value, rdr)

--- a/src/elements/module.rs
+++ b/src/elements/module.rs
@@ -576,7 +576,7 @@ impl Module {
 impl Deserialize for Module {
 	type Error = super::Error;
 
-	fn deserialize<R: io::Read>(reader: &mut R) -> Result<Self, Self::Error> {
+	fn deserialize<R: io::ReadSeek>(reader: &mut R) -> Result<Self, Self::Error> {
 		let mut sections = Vec::new();
 
 		let mut magic = [0u8; 4];
@@ -659,6 +659,18 @@ impl<'a> io::Read for PeekSection<'a> {
 		Ok(())
 	}
 }
+
+#[cfg(feature = "offsets")]
+impl<'a> io::Seek for PeekSection<'a> {
+	fn seek(&mut self, seek_from: io::SeekFrom) -> io::Result<u64> {
+		self.cursor = io::seek_impl(self.region.len(), self.cursor, seek_from)?;
+
+		// Casting up from usize to u64 should be fine.
+		Ok(self.cursor as u64)
+	}
+}
+
+impl<'a> io::ReadSeek for PeekSection<'a> {}
 
 /// Returns size of the module in the provided stream.
 pub fn peek_size(source: &[u8]) -> usize {

--- a/src/elements/name_section.rs
+++ b/src/elements/name_section.rs
@@ -65,7 +65,7 @@ impl NameSection {
 
 impl NameSection {
 	/// Deserialize a name section.
-	pub fn deserialize<R: io::Read>(module: &Module, rdr: &mut R) -> Result<Self, Error> {
+	pub fn deserialize<R: io::ReadSeek>(module: &Module, rdr: &mut R) -> Result<Self, Error> {
 		let mut module_name: Option<ModuleNameSubsection> = None;
 		let mut function_names: Option<FunctionNameSubsection> = None;
 		let mut local_names: Option<LocalNameSubsection> = None;
@@ -175,7 +175,7 @@ impl Serialize for ModuleNameSubsection {
 impl Deserialize for ModuleNameSubsection {
 	type Error = Error;
 
-	fn deserialize<R: io::Read>(rdr: &mut R) -> Result<ModuleNameSubsection, Error> {
+	fn deserialize<R: io::ReadSeek>(rdr: &mut R) -> Result<ModuleNameSubsection, Error> {
 		let name = String::deserialize(rdr)?;
 		Ok(ModuleNameSubsection { name })
 	}
@@ -199,7 +199,7 @@ impl FunctionNameSubsection {
 	}
 
 	/// Deserialize names, making sure that all names correspond to functions.
-	pub fn deserialize<R: io::Read>(
+	pub fn deserialize<R: io::ReadSeek>(
 		module: &Module,
 		rdr: &mut R,
 	) -> Result<FunctionNameSubsection, Error> {
@@ -236,7 +236,7 @@ impl LocalNameSubsection {
 
 	/// Deserialize names, making sure that all names correspond to local
 	/// variables.
-	pub fn deserialize<R: io::Read>(
+	pub fn deserialize<R: io::ReadSeek>(
 		module: &Module,
 		rdr: &mut R,
 	) -> Result<LocalNameSubsection, Error> {

--- a/src/elements/primitives.rs
+++ b/src/elements/primitives.rs
@@ -41,7 +41,7 @@ impl From<usize> for VarUint32 {
 impl Deserialize for VarUint32 {
 	type Error = Error;
 
-	fn deserialize<R: io::Read>(reader: &mut R) -> Result<Self, Self::Error> {
+	fn deserialize<R: io::ReadSeek>(reader: &mut R) -> Result<Self, Self::Error> {
 		let mut res = 0;
 		let mut shift = 0;
 		let mut u8buf = [0u8; 1];
@@ -101,7 +101,7 @@ impl From<VarUint64> for u64 {
 impl Deserialize for VarUint64 {
 	type Error = Error;
 
-	fn deserialize<R: io::Read>(reader: &mut R) -> Result<Self, Self::Error> {
+	fn deserialize<R: io::ReadSeek>(reader: &mut R) -> Result<Self, Self::Error> {
 		let mut res = 0;
 		let mut shift = 0;
 		let mut u8buf = [0u8; 1];
@@ -172,7 +172,7 @@ impl From<u8> for VarUint7 {
 impl Deserialize for VarUint7 {
 	type Error = Error;
 
-	fn deserialize<R: io::Read>(reader: &mut R) -> Result<Self, Self::Error> {
+	fn deserialize<R: io::ReadSeek>(reader: &mut R) -> Result<Self, Self::Error> {
 		let mut u8buf = [0u8; 1];
 		reader.read(&mut u8buf)?;
 		Ok(VarUint7(u8buf[0]))
@@ -208,7 +208,7 @@ impl From<i8> for VarInt7 {
 impl Deserialize for VarInt7 {
 	type Error = Error;
 
-	fn deserialize<R: io::Read>(reader: &mut R) -> Result<Self, Self::Error> {
+	fn deserialize<R: io::ReadSeek>(reader: &mut R) -> Result<Self, Self::Error> {
 		let mut u8buf = [0u8; 1];
 		reader.read(&mut u8buf)?;
 
@@ -261,7 +261,7 @@ impl From<u8> for Uint8 {
 impl Deserialize for Uint8 {
 	type Error = Error;
 
-	fn deserialize<R: io::Read>(reader: &mut R) -> Result<Self, Self::Error> {
+	fn deserialize<R: io::ReadSeek>(reader: &mut R) -> Result<Self, Self::Error> {
 		let mut u8buf = [0u8; 1];
 		reader.read(&mut u8buf)?;
 		Ok(Uint8(u8buf[0]))
@@ -296,7 +296,7 @@ impl From<i32> for VarInt32 {
 impl Deserialize for VarInt32 {
 	type Error = Error;
 
-	fn deserialize<R: io::Read>(reader: &mut R) -> Result<Self, Self::Error> {
+	fn deserialize<R: io::ReadSeek>(reader: &mut R) -> Result<Self, Self::Error> {
 		let mut res = 0;
 		let mut shift = 0;
 		let mut u8buf = [0u8; 1];
@@ -371,7 +371,7 @@ impl From<i64> for VarInt64 {
 impl Deserialize for VarInt64 {
 	type Error = Error;
 
-	fn deserialize<R: io::Read>(reader: &mut R) -> Result<Self, Self::Error> {
+	fn deserialize<R: io::ReadSeek>(reader: &mut R) -> Result<Self, Self::Error> {
 		let mut res = 0i64;
 		let mut shift = 0;
 		let mut u8buf = [0u8; 1];
@@ -435,7 +435,7 @@ pub struct Uint32(u32);
 impl Deserialize for Uint32 {
 	type Error = Error;
 
-	fn deserialize<R: io::Read>(reader: &mut R) -> Result<Self, Self::Error> {
+	fn deserialize<R: io::ReadSeek>(reader: &mut R) -> Result<Self, Self::Error> {
 		let mut buf = [0u8; 4];
 		reader.read(&mut buf)?;
 		// todo check range
@@ -471,7 +471,7 @@ pub struct Uint64(u64);
 impl Deserialize for Uint64 {
 	type Error = Error;
 
-	fn deserialize<R: io::Read>(reader: &mut R) -> Result<Self, Self::Error> {
+	fn deserialize<R: io::ReadSeek>(reader: &mut R) -> Result<Self, Self::Error> {
 		let mut buf = [0u8; 8];
 		reader.read(&mut buf)?;
 		// todo check range
@@ -519,7 +519,7 @@ impl From<bool> for VarUint1 {
 impl Deserialize for VarUint1 {
 	type Error = Error;
 
-	fn deserialize<R: io::Read>(reader: &mut R) -> Result<Self, Self::Error> {
+	fn deserialize<R: io::ReadSeek>(reader: &mut R) -> Result<Self, Self::Error> {
 		let mut u8buf = [0u8; 1];
 		reader.read(&mut u8buf)?;
 		match u8buf[0] {
@@ -542,7 +542,7 @@ impl Serialize for VarUint1 {
 impl Deserialize for String {
 	type Error = Error;
 
-	fn deserialize<R: io::Read>(reader: &mut R) -> Result<Self, Self::Error> {
+	fn deserialize<R: io::ReadSeek>(reader: &mut R) -> Result<Self, Self::Error> {
 		let length = u32::from(VarUint32::deserialize(reader)?) as usize;
 		if length > 0 {
 			String::from_utf8(buffered_read!(PRIMITIVES_BUFFER_LENGTH, length, reader))
@@ -581,7 +581,7 @@ where
 {
 	type Error = T::Error;
 
-	fn deserialize<R: io::Read>(reader: &mut R) -> Result<Self, Self::Error> {
+	fn deserialize<R: io::ReadSeek>(reader: &mut R) -> Result<Self, Self::Error> {
 		let count: usize = VarUint32::deserialize(reader)?.into();
 		let mut result = Vec::new();
 		for _ in 0..count {

--- a/src/elements/reloc_section.rs
+++ b/src/elements/reloc_section.rs
@@ -75,7 +75,7 @@ impl RelocSection {
 
 impl RelocSection {
 	/// Deserialize a reloc section.
-	pub fn deserialize<R: io::Read>(name: String, rdr: &mut R) -> Result<Self, Error> {
+	pub fn deserialize<R: io::ReadSeek>(name: String, rdr: &mut R) -> Result<Self, Error> {
 		let section_id = VarUint32::deserialize(rdr)?.into();
 
 		let relocation_section_name =
@@ -198,7 +198,7 @@ pub enum RelocationEntry {
 impl Deserialize for RelocationEntry {
 	type Error = Error;
 
-	fn deserialize<R: io::Read>(rdr: &mut R) -> Result<Self, Self::Error> {
+	fn deserialize<R: io::ReadSeek>(rdr: &mut R) -> Result<Self, Self::Error> {
 		match VarUint7::deserialize(rdr)?.into() {
 			FUNCTION_INDEX_LEB => Ok(RelocationEntry::FunctionIndexLeb {
 				offset: VarUint32::deserialize(rdr)?.into(),

--- a/src/elements/section.rs
+++ b/src/elements/section.rs
@@ -217,11 +217,11 @@ pub(crate) struct SectionReader {
 
 impl SectionReader {
 	pub fn new<R: io::ReadSeek>(reader: &mut R) -> Result<Self, elements::Error> {
-		let length = u32::from(VarUint32::deserialize(reader)?) as usize;
-
 		// The absolute offset of this section
 		#[cfg(feature = "offsets")]
 		let offset = reader.seek(io::SeekFrom::Current(0))?;
+
+		let length = u32::from(VarUint32::deserialize(reader)?) as usize;
 
 		let inner_buffer = buffered_read!(ENTRIES_BUFFER_LENGTH, length, reader);
 		let declared_length = inner_buffer.len();
@@ -975,7 +975,7 @@ mod tests {
 				let offsets = func_body.code().offsets();
 				assert_eq!(
 					offsets,
-					[7u64, 9, 11, 13, 15, 17, 18, 20, 22, 24, 25, 27, 28, 30, 32, 33]
+					[5u64, 7, 9, 11, 13, 15, 16, 18, 20, 22, 23, 25, 26, 28, 30, 31]
 				);
 			},
 			_ => {

--- a/src/elements/segment.rs
+++ b/src/elements/segment.rs
@@ -91,7 +91,7 @@ impl Deserialize for ElementSegment {
 	type Error = Error;
 
 	#[cfg(not(feature = "bulk"))]
-	fn deserialize<R: io::Read>(reader: &mut R) -> Result<Self, Self::Error> {
+	fn deserialize<R: io::ReadSeek>(reader: &mut R) -> Result<Self, Self::Error> {
 		let index: u32 = VarUint32::deserialize(reader)?.into();
 		let offset = InitExpr::deserialize(reader)?;
 		let members: Vec<u32> = CountedList::<VarUint32>::deserialize(reader)?
@@ -104,7 +104,7 @@ impl Deserialize for ElementSegment {
 	}
 
 	#[cfg(feature = "bulk")]
-	fn deserialize<R: io::Read>(reader: &mut R) -> Result<Self, Self::Error> {
+	fn deserialize<R: io::ReadSeek>(reader: &mut R) -> Result<Self, Self::Error> {
 		// This piece of data was treated as `index` [of the table], but was repurposed
 		// for flags in bulk-memory operations proposal.
 		let flags: u32 = VarUint32::deserialize(reader)?.into();
@@ -233,7 +233,7 @@ impl Deserialize for DataSegment {
 	type Error = Error;
 
 	#[cfg(not(feature = "bulk"))]
-	fn deserialize<R: io::Read>(reader: &mut R) -> Result<Self, Self::Error> {
+	fn deserialize<R: io::ReadSeek>(reader: &mut R) -> Result<Self, Self::Error> {
 		let index = VarUint32::deserialize(reader)?;
 		let offset = InitExpr::deserialize(reader)?;
 		let value_len = u32::from(VarUint32::deserialize(reader)?) as usize;
@@ -243,7 +243,7 @@ impl Deserialize for DataSegment {
 	}
 
 	#[cfg(feature = "bulk")]
-	fn deserialize<R: io::Read>(reader: &mut R) -> Result<Self, Self::Error> {
+	fn deserialize<R: io::ReadSeek>(reader: &mut R) -> Result<Self, Self::Error> {
 		let flags: u32 = VarUint32::deserialize(reader)?.into();
 		let index = if flags == FLAG_MEMZERO || flags == FLAG_PASSIVE {
 			0u32

--- a/src/elements/types.rs
+++ b/src/elements/types.rs
@@ -15,7 +15,7 @@ pub enum Type {
 impl Deserialize for Type {
 	type Error = Error;
 
-	fn deserialize<R: io::Read>(reader: &mut R) -> Result<Self, Self::Error> {
+	fn deserialize<R: io::ReadSeek>(reader: &mut R) -> Result<Self, Self::Error> {
 		Ok(Type::Function(FunctionType::deserialize(reader)?))
 	}
 }
@@ -49,7 +49,7 @@ pub enum ValueType {
 impl Deserialize for ValueType {
 	type Error = Error;
 
-	fn deserialize<R: io::Read>(reader: &mut R) -> Result<Self, Self::Error> {
+	fn deserialize<R: io::ReadSeek>(reader: &mut R) -> Result<Self, Self::Error> {
 		let val = VarInt7::deserialize(reader)?;
 
 		match val.into() {
@@ -110,7 +110,7 @@ pub enum BlockType {
 impl Deserialize for BlockType {
 	type Error = Error;
 
-	fn deserialize<R: io::Read>(reader: &mut R) -> Result<Self, Self::Error> {
+	fn deserialize<R: io::ReadSeek>(reader: &mut R) -> Result<Self, Self::Error> {
 		let val = VarInt32::deserialize(reader)?;
 
 		match val.into() {
@@ -197,7 +197,7 @@ impl FunctionType {
 impl Deserialize for FunctionType {
 	type Error = Error;
 
-	fn deserialize<R: io::Read>(reader: &mut R) -> Result<Self, Self::Error> {
+	fn deserialize<R: io::ReadSeek>(reader: &mut R) -> Result<Self, Self::Error> {
 		let form: u8 = VarUint7::deserialize(reader)?.into();
 
 		if form != 0x60 {
@@ -250,7 +250,7 @@ pub enum TableElementType {
 impl Deserialize for TableElementType {
 	type Error = Error;
 
-	fn deserialize<R: io::Read>(reader: &mut R) -> Result<Self, Self::Error> {
+	fn deserialize<R: io::ReadSeek>(reader: &mut R) -> Result<Self, Self::Error> {
 		let val = VarInt7::deserialize(reader)?;
 
 		match val.into() {

--- a/src/io.rs
+++ b/src/io.rs
@@ -20,6 +20,10 @@ pub enum Error {
 
 	#[cfg(feature = "std")]
 	Io(std::io::Error),
+
+	/// Invalid offset for seek
+	#[cfg(feature = "offsets")]
+	InvalidSeek,
 }
 
 /// IO specific Result.
@@ -39,6 +43,57 @@ pub trait Read {
 	fn read(&mut self, buf: &mut [u8]) -> Result<()>;
 }
 
+/// Enumeration of possible methods to seek within an I/O object.
+///
+/// It is used by the `Seek` trait
+#[cfg(feature = "offsets")]
+pub enum SeekFrom {
+	/// Sets the offset to the provided number of bytes.
+	Start(u64),
+
+	/// Sets the offset to the size of this object plus the specified number of bytes.
+	///
+	///It is possible to seek beyond the end of an object, but it’s an error to seek before byte 0.
+	End(i64),
+
+	/// Sets the offset to the current position plus the specified number of bytes.
+	///
+	/// It is possible to seek beyond the end of an object, but it’s an error to seek before byte 0.
+	Current(i64),
+}
+
+#[cfg(feature = "offsets")]
+impl From<SeekFrom> for io::SeekFrom {
+	/// Convert from our implemtation of `SeekFrom` to `std::io::SeekFrom`
+	fn from(seek_from: SeekFrom) -> Self {
+		match seek_from {
+			SeekFrom::Start(offset) => io::SeekFrom::Start(offset),
+			SeekFrom::End(offset) => io::SeekFrom::End(offset),
+			SeekFrom::Current(offset) => io::SeekFrom::Current(offset),
+		}
+	}
+}
+
+#[cfg(feature = "offsets")]
+pub trait Seek {
+	/// Seek to an offset, in bytes, in a stream.
+	///
+	/// Check [std::io::Seek](https://doc.rust-lang.org/stable/std/io/trait.Seek.html#tymethod.seek) for any
+	/// details about the behaviour.
+	fn seek(&mut self, pos: SeekFrom) -> Result<u64>;
+}
+
+/// If the `offsets` feature is enabled,
+/// we require `Read + Seek` so that we can
+/// get the current position within the buffer.
+#[cfg(feature = "offsets")]
+pub trait ReadSeek: Read + Seek {}
+
+/// Only require our buffer to be `Read` if
+/// `offsets` is disabled.
+#[cfg(not(feature = "offsets"))]
+pub trait ReadSeek: Read {}
+
 /// Reader that saves the last position.
 pub struct Cursor<T> {
 	inner: T,
@@ -55,6 +110,8 @@ impl<T> Cursor<T> {
 	}
 }
 
+impl<T: AsRef<[u8]>> ReadSeek for Cursor<T> {}
+
 impl<T: AsRef<[u8]>> Read for Cursor<T> {
 	fn read(&mut self, buf: &mut [u8]) -> Result<()> {
 		let slice = self.inner.as_ref();
@@ -66,6 +123,56 @@ impl<T: AsRef<[u8]>> Read for Cursor<T> {
 		buf.copy_from_slice(&slice[self.pos..(self.pos + requested)]);
 		self.pos += requested;
 		Ok(())
+	}
+}
+
+#[cfg(feature = "offsets")]
+pub fn seek_impl(
+	buffer_size: usize,
+	current_position: usize,
+	seek_from: SeekFrom,
+) -> Result<usize> {
+	fn calculate_new_position(reference_position: usize, offset: i64) -> Result<usize> {
+		// Maybe I'm overly cautious here...
+
+		// First, check if the size fits into i64...
+		let reference_position: i64 =
+			reference_position.try_into().map_err(|_| Error::InvalidSeek)?;
+
+		// Then, check if there is an overflow or not
+		let new_position = reference_position.checked_add(offset).ok_or(Error::InvalidSeek)?;
+
+		// Finally, check if the new_position is < 0, which is not allowed
+		// according to the documentation of std::io::SeekFrom
+		if new_position < 0 {
+			return Err(Error::InvalidSeek)
+		}
+
+		// On 32-bit systems, usize might be too small for a u64 value.
+		// Again, maybe I'm overly cautious here
+		let new_position = new_position.try_into().map_err(|_| Error::InvalidSeek)?;
+
+		Ok(new_position)
+	}
+
+	match seek_from {
+		SeekFrom::Start(offset) => {
+			// On 32-bit systems, usize might be too small for a u64 value.
+			// Again, maybe I'm overly cautious here
+			offset.try_into().map_err(|_| Error::InvalidSeek)
+		},
+		SeekFrom::End(offset) => calculate_new_position(buffer_size, offset),
+		SeekFrom::Current(offset) => calculate_new_position(current_position, offset),
+	}
+}
+
+#[cfg(feature = "offsets")]
+impl<T: AsRef<[u8]>> Seek for Cursor<T> {
+	fn seek(&mut self, seek_from: SeekFrom) -> Result<u64> {
+		self.pos = seek_impl(self.inner.as_ref().len(), self.pos, seek_from)?;
+
+		// Casting up from usize to u64 should be fine though.
+		Ok(self.pos as u64)
 	}
 }
 
@@ -83,6 +190,16 @@ impl<T: io::Read> Read for T {
 		self.read_exact(buf).map_err(Error::Io)
 	}
 }
+
+#[cfg(feature = "offsets")]
+impl<T: io::Seek> Seek for T {
+	fn seek(&mut self, pos: SeekFrom) -> Result<u64> {
+		self.seek(pos.into()).map_err(Error::Io)
+	}
+}
+
+#[cfg(feature = "std")]
+impl<T: io::Read + io::Seek> ReadSeek for T {}
 
 #[cfg(feature = "std")]
 impl<T: io::Write> Write for T {
@@ -114,5 +231,61 @@ mod tests {
 		let mut cursor = Cursor::new(vec![0u8]);
 		let mut buf = [0, 1, 2];
 		assert!(cursor.read(&mut buf[..]).is_err());
+	}
+
+	#[cfg(feature = "offsets")]
+	mod instruction_offset_tests {
+		use super::*;
+
+		#[test]
+		fn seek_end() {
+			let mut cursor = Cursor::new(vec![0xFF; 10]);
+
+			// Trivial checks
+			assert_eq!(cursor.seek(SeekFrom::End(0)).unwrap(), 10);
+			assert_eq!(cursor.seek(SeekFrom::End(-1)).unwrap(), 9);
+			assert_eq!(cursor.seek(SeekFrom::End(-2)).unwrap(), 8);
+
+			// Check that we cannot seek to a position < 0
+			assert!(cursor.seek(SeekFrom::End(-11)).is_err());
+
+			// We are at position=10, check if we can go back to 0
+			assert_eq!(cursor.seek(SeekFrom::End(-10)).unwrap(), 0);
+
+			// Seek beyond the end of the buffer is allowed according to the spec
+			assert_eq!(cursor.seek(SeekFrom::End(15)).unwrap(), 25);
+		}
+
+		#[test]
+		fn seek_current() {
+			let mut cursor = Cursor::new(vec![0xFF; 10]);
+
+			// Trivial checks
+			assert_eq!(cursor.seek(SeekFrom::Current(0)).unwrap(), 0);
+			assert_eq!(cursor.seek(SeekFrom::Current(1)).unwrap(), 1);
+			assert_eq!(cursor.seek(SeekFrom::Current(1)).unwrap(), 2);
+
+			// Check that we cannot seek to a position < 0
+			assert!(cursor.seek(SeekFrom::Current(-3)).is_err());
+
+			// We are at position=10, check if we can go back to 0
+			assert_eq!(cursor.seek(SeekFrom::Current(-2)).unwrap(), 0);
+
+			// Seek beyond the end of the buffer is allowed according to the spec
+			assert_eq!(cursor.seek(SeekFrom::Current(15)).unwrap(), 15);
+		}
+
+		#[test]
+		fn seek_start() {
+			let mut cursor = Cursor::new(vec![0xFF; 10]);
+
+			// Trivial checks
+			assert_eq!(cursor.seek(SeekFrom::Start(0)).unwrap(), 0);
+			assert_eq!(cursor.seek(SeekFrom::Start(1)).unwrap(), 1);
+			assert_eq!(cursor.seek(SeekFrom::Start(2)).unwrap(), 2);
+
+			// Seek beyond the end of the buffer is allowed according to the spec
+			assert_eq!(cursor.seek(SeekFrom::Start(15)).unwrap(), 15);
+		}
 	}
 }


### PR DESCRIPTION
As briefly discussed in #323, this feature adds the `offsets()` function to the `Instructions` struct to get the absolute offsets of every single instruction. `CodeSection` has the `offset()` function to get the absolute offset of the code section. Both are useful for computing the instruction offsets relative to start of the code section, for example when using the addr2line crate to
gather the original location in the source code for a given instruction. To achieve this, the `ReadSeek` trait bound was used instead of Read for all `deserialize` functions.
If "offsets" is enabled, `ReadSeek` requires `Read + Seek`, if not, it only requires `Read`

For now, only `Instructions` and `CodeSection` provide the `offset` function, but this could easily be extended if needed.

This should also close #294.

Note: I'm pretty unhappy with the name of the `ReadSeek` trait, so if anybody has a better suggestion, I'm all open for it.