### PR TITLE
Fix testsuite on windows

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -53,7 +53,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: ["ubuntu-latest", "macos-latest"]
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
         toolchain: ["stable", "nightly"]
     runs-on: ${{ matrix.os }}
     steps:

--- a/testsuite/src/lib.rs
+++ b/testsuite/src/lib.rs
@@ -1,6 +1,6 @@
 #![cfg(test)]
 
-use std::ffi::OsStr;
+use std::{ffi::OsStr, path::Path};
 
 mod run;
 
@@ -12,7 +12,8 @@ const BASIC_BLACKLIST: [&str; 2] = [
 
 #[test_generator::test_resources("testsuite/spec/*.wast")]
 fn basic(path: &str) {
-	let blacklisted = std::path::Path::new(path)
+	let path = Path::new(path);
+	let blacklisted = path
 		.file_name()
 		.map(|file| BASIC_BLACKLIST.iter().any(|black| OsStr::new(black) == file))
 		.unwrap_or(false);
@@ -24,5 +25,5 @@ fn basic(path: &str) {
 
 #[test_generator::test_resources("testsuite/spec/proposals/threads/*.wast")]
 fn threads(path: &str) {
-	run::check(path);
+	run::check(Path::new(path));
 }

--- a/testsuite/src/run.rs
+++ b/testsuite/src/run.rs
@@ -1,10 +1,12 @@
+use std::path::Path;
+
 use parity_wasm::elements::{deserialize_buffer, serialize, Module};
 use wast::{
 	parser::{parse, ParseBuffer},
 	QuoteModule, Wast, WastDirective,
 };
 
-pub fn check(path: &str) {
+pub fn check(path: &Path) {
 	let path = path.strip_prefix("testsuite/").unwrap();
 	let source = std::fs::read_to_string(path).unwrap();
 	let buffer = ParseBuffer::new(&source).unwrap();


### PR DESCRIPTION
Testsuite fails on windows because of manual filepath handling. Fixed it by using `std::path::Path` instead of `str`.