### PR TITLE
Add warning about deprecation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parity-wasm"
-version = "0.45.0"
+version = "0.45.1"
 authors = ["Nikolay Volf <nikvolf@gmail.com>", "Svyatoslav Nikolsky <svyatonik@yandex.ru>", "Sergey Shulepov <s.pepyakin@gmail.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # parity-wasm
 
+> :warning: **This repository/crate is deprecated and unmaintained**: If you interested in maintaining
+this crate consider forking it. We can provide a link to the most promising forks here.
+
 Low-level WebAssembly format library.
 
 [![Build Status](https://travis-ci.org/paritytech/parity-wasm.svg?branch=master)](https://travis-ci.org/paritytech/parity-wasm)


### PR DESCRIPTION
Parity will no longer maintain this. We will be pushing for making `wasmparser` and `wasmencoder` `no_std` compatible.